### PR TITLE
Fix QR spec file selection inputs and directory fallback

### DIFF
--- a/qr/spec.html
+++ b/qr/spec.html
@@ -90,22 +90,22 @@ main { grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr); }
       <div>
         <label><strong>画像フォルダ</strong>（Chrome系: webkitdirectory）</label><br/>
         <input id="dirInput" type="file" accept="image/*" webkitdirectory multiple />
-        <div class="muted">フォルダ配下の画像をまとめて処理します（ブラウザ依存）。</div>
+        <div class="muted" id="dirSupportMessage">フォルダ配下の画像をまとめて処理します（ブラウザ依存）。</div>
       </div>
     </div>
 
     <hr style="border:none;border-top:1px solid #eee;margin:12px 0;"/>
 
     <div class="row">
-      <button id="startCam" class="primary">📷 カメラ開始</button>
-      <button id="stopCam" disabled>⏹ 停止</button>
+      <button id="startCam" class="primary" type="button">📷 カメラ開始</button>
+      <button id="stopCam" disabled type="button">⏹ 停止</button>
       <label class="small"><input type="checkbox" id="dedup" checked /> 重複抑制（同じpayloadは追加しない）</label>
       <label class="small"><input type="checkbox" id="recordNoQr" /> （画像のみ）QR無しも記録する</label>
     </div>
 
     <div class="row">
-      <button id="exportCsv" class="primary">⬇ CSVをダウンロード</button>
-      <button id="clear">🧹 クリア</button>
+      <button id="exportCsv" class="primary" type="button">⬇ CSVをダウンロード</button>
+      <button id="clear" type="button">🧹 クリア</button>
       <span class="muted">※ カメラは <strong>https</strong> または <strong>localhost</strong> でないと起動できない場合があります。</span>
     </div>
 
@@ -131,7 +131,7 @@ main { grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr); }
     </div>
 
     <div class="row">
-      <button id="toggleModel">モデルJSONを表示/非表示</button>
+      <button id="toggleModel" type="button">モデルJSONを表示/非表示</button>
       <span class="muted">（実装が扱う“型”と“等価クラス”をここで固定化）</span>
     </div>
     <pre id="modelJson" style="display:none;"></pre>
@@ -565,7 +565,10 @@ function addRecords(newOnes, { allowNoQr } = { allowNoQr: false }) {
 }
 async function handleFiles(fileList, sourceKind) {
   const files = Array.from(fileList || []);
-  if (files.length === 0) return;
+  if (files.length === 0) {
+    log("ファイルが選択されていません");
+    return;
+  }
   log(`${files.length} 件の画像を処理します… (${sourceKind})`);
   for (const f of files) {
     const rs = await usecase.processImageFile(f, sourceKind, OutputMode.new_file);
@@ -631,8 +634,36 @@ el.toggleModel.addEventListener("click", () => {
   const show = (el.modelJson.style.display === "none");
   el.modelJson.style.display = show ? "block" : "none";
 });
-el.fileInput.addEventListener("change", async () => { await handleFiles(el.fileInput.files, InputSourceKind.image_file); el.fileInput.value = ""; });
-el.dirInput.addEventListener("change", async () => { await handleFiles(el.dirInput.files, InputSourceKind.image_dir); el.dirInput.value = ""; });
+el.fileInput.addEventListener("change", async () => {
+  const files = Array.from(el.fileInput.files || []);
+  try {
+    await handleFiles(files, InputSourceKind.image_file);
+  } catch (e) {
+    const msg = (e && e.message) ? e.message : String(e);
+    log(`画像ファイル処理中にエラー: ${msg}`);
+  } finally {
+    el.fileInput.value = "";
+  }
+});
+const dirSupportMessage = document.getElementById("dirSupportMessage");
+const supportsDirectoryUpload = "webkitdirectory" in document.createElement("input");
+if (!supportsDirectoryUpload) {
+  el.dirInput.disabled = true;
+  if (dirSupportMessage) dirSupportMessage.textContent = "このブラウザはフォルダ選択に対応していません。画像ファイルから選択してください。";
+} else {
+  if (dirSupportMessage) dirSupportMessage.textContent = "フォルダ配下の画像をまとめて処理します（Chrome / Edgeなど対応ブラウザのみ）。";
+}
+el.dirInput.addEventListener("change", async () => {
+  const files = Array.from(el.dirInput.files || []);
+  try {
+    await handleFiles(files, InputSourceKind.image_dir);
+  } catch (e) {
+    const msg = (e && e.message) ? e.message : String(e);
+    log(`画像フォルダ処理中にエラー: ${msg}`);
+  } finally {
+    el.dirInput.value = "";
+  }
+});
 el.startCam.addEventListener("click", startCamera);
 el.stopCam.addEventListener("click", stopCamera);
 


### PR DESCRIPTION
## Summary
- ensure image file and folder selections are retained while processing and clear inputs only after handling
- add graceful fallback and messaging when directory selection is unsupported
- mark action buttons as non-submitting buttons to avoid unintended resets

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bd4754fec83338548dee1169069a9)