### PR TITLE
Add SPICA course landing entry

### DIFF
--- a/btd/design.html
+++ b/btd/design.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SPICA | Design</title>
+  <style>
+    body{
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", Meiryo, Arial, sans-serif;
+      margin: 0 auto;
+      max-width: 960px;
+      padding: 32px 18px 48px;
+      line-height: 1.7;
+      color: #e8e8f0;
+      background: radial-gradient(900px 480px at 80% 10%, rgba(255,94,168,.12), transparent 50%), #0c0e1a;
+    }
+    a{ color: #7cf7ff; }
+    header{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap: 12px;
+      margin-bottom: 24px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid rgba(255,255,255,.14);
+    }
+    h1{ margin: 0; letter-spacing: .05em; }
+    .tag{
+      display:inline-flex;
+      align-items:center;
+      gap: 8px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.20);
+      background: rgba(255,255,255,.05);
+      color: rgba(255,255,255,.78);
+      letter-spacing: .05em;
+      font-size: 12px;
+    }
+    .tag .dot{
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #ff5ea8, rgba(255,94,168,.25));
+      box-shadow: 0 0 18px rgba(255,94,168,.45);
+    }
+    section{ margin: 20px 0; padding: 14px 0; }
+    h2{ margin-bottom: 8px; }
+    ul{ padding-left: 20px; }
+    .links{ display:flex; flex-wrap:wrap; gap: 10px; margin-top: 8px; }
+    .btn{
+      display:inline-flex;
+      align-items:center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.18);
+      background: rgba(255,255,255,.06);
+      color: #f6f7fb;
+      text-decoration:none;
+      font-weight: 650;
+    }
+    .btn .dot{
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #7cf7ff, rgba(124,247,255,.25));
+      box-shadow: 0 0 18px rgba(124,247,255,.45);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <div class="tag"><span class="dot" aria-hidden="true"></span>SPICA / Beat Diffusion</div>
+      <h1>設計（Design / Pipeline v0.1）</h1>
+    </div>
+    <a class="btn" href="../index.html"><span class="dot" aria-hidden="true"></span>トップへ戻る</a>
+  </header>
+
+  <section>
+    <p>
+      SPICAのパイプライン設計をまとめています。条件JSONの取り回し、ノイズ除去ループ、BeatSpec / MIDI出力までの
+      役割分担を簡潔に整理し、実装へ進みやすくするためのガイドです。
+    </p>
+  </section>
+
+  <section>
+    <h2>含まれるもの</h2>
+    <ul>
+      <li>入力条件（プロンプトJSON）の構造</li>
+      <li>スコア計算・ルール適用の流れ</li>
+      <li>BeatSpec / MIDI生成までのステップ</li>
+      <li>Codex向けIssue分解のヒント</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>リンク</h2>
+    <div class="links">
+      <a class="btn" href="overview.html"><span class="dot" aria-hidden="true"></span>仕様（Overview）へ戻る</a>
+      <a class="btn" href="implement.html"><span class="dot" aria-hidden="true"></span>実装（Implement）を読む</a>
+    </div>
+  </section>
+</body>
+</html>

--- a/btd/implement.html
+++ b/btd/implement.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SPICA | Implement</title>
+  <style>
+    body{
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", Meiryo, Arial, sans-serif;
+      margin: 0 auto;
+      max-width: 960px;
+      padding: 32px 18px 48px;
+      line-height: 1.7;
+      color: #e8e8f0;
+      background: radial-gradient(900px 480px at 80% 10%, rgba(255,94,168,.12), transparent 50%), #0c0e1a;
+    }
+    a{ color: #7cf7ff; }
+    header{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap: 12px;
+      margin-bottom: 24px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid rgba(255,255,255,.14);
+    }
+    h1{ margin: 0; letter-spacing: .05em; }
+    .tag{
+      display:inline-flex;
+      align-items:center;
+      gap: 8px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.20);
+      background: rgba(255,255,255,.05);
+      color: rgba(255,255,255,.78);
+      letter-spacing: .05em;
+      font-size: 12px;
+    }
+    .tag .dot{
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #ff5ea8, rgba(255,94,168,.25));
+      box-shadow: 0 0 18px rgba(255,94,168,.45);
+    }
+    section{ margin: 20px 0; padding: 14px 0; }
+    h2{ margin-bottom: 8px; }
+    ul{ padding-left: 20px; }
+    .links{ display:flex; flex-wrap:wrap; gap: 10px; margin-top: 8px; }
+    .btn{
+      display:inline-flex;
+      align-items:center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.18);
+      background: rgba(255,255,255,.06);
+      color: #f6f7fb;
+      text-decoration:none;
+      font-weight: 650;
+    }
+    .btn .dot{
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #7cf7ff, rgba(124,247,255,.25));
+      box-shadow: 0 0 18px rgba(124,247,255,.45);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <div class="tag"><span class="dot" aria-hidden="true"></span>SPICA / Beat Diffusion</div>
+      <h1>実装（Implement / Codex Issue設計）</h1>
+    </div>
+    <a class="btn" href="../index.html"><span class="dot" aria-hidden="true"></span>トップへ戻る</a>
+  </header>
+
+  <section>
+    <p>
+      実装ステップをCodex向けIssueに落とし込むための簡易メモです。
+      ルール・スコアの計算手順、MIDI組み立て、テスト観点を小さなタスクに分割して進行しやすくしています。
+    </p>
+  </section>
+
+  <section>
+    <h2>実装タスクリストの例</h2>
+    <ul>
+      <li>条件JSONの読み取りとバリデーション</li>
+      <li>ホワイトノイズの初期化とシード管理</li>
+      <li>ルール適用とスコア計算のループ</li>
+      <li>BeatSpec / MIDI出力の整形と保存</li>
+      <li>簡易テストとデモ生成</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>リンク</h2>
+    <div class="links">
+      <a class="btn" href="overview.html"><span class="dot" aria-hidden="true"></span>仕様（Overview）へ戻る</a>
+      <a class="btn" href="design.html"><span class="dot" aria-hidden="true"></span>設計（Design）へ戻る</a>
+    </div>
+  </section>
+</body>
+</html>

--- a/btd/overview.html
+++ b/btd/overview.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SPICA | Overview</title>
+  <style>
+    body{
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", Meiryo, Arial, sans-serif;
+      margin: 0 auto;
+      max-width: 960px;
+      padding: 32px 18px 48px;
+      line-height: 1.7;
+      color: #e8e8f0;
+      background: radial-gradient(900px 480px at 80% 10%, rgba(255,94,168,.12), transparent 50%), #0c0e1a;
+    }
+    a{ color: #7cf7ff; }
+    header{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap: 12px;
+      margin-bottom: 24px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid rgba(255,255,255,.14);
+    }
+    h1{ margin: 0; letter-spacing: .05em; }
+    .tag{
+      display:inline-flex;
+      align-items:center;
+      gap: 8px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.20);
+      background: rgba(255,255,255,.05);
+      color: rgba(255,255,255,.78);
+      letter-spacing: .05em;
+      font-size: 12px;
+    }
+    .tag .dot{
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #ff5ea8, rgba(255,94,168,.25));
+      box-shadow: 0 0 18px rgba(255,94,168,.45);
+    }
+    section{ margin: 20px 0; padding: 14px 0; }
+    h2{ margin-bottom: 8px; }
+    ul{ padding-left: 20px; }
+    .links{ display:flex; flex-wrap:wrap; gap: 10px; margin-top: 8px; }
+    .btn{
+      display:inline-flex;
+      align-items:center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.18);
+      background: rgba(255,255,255,.06);
+      color: #f6f7fb;
+      text-decoration:none;
+      font-weight: 650;
+    }
+    .btn .dot{
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #7cf7ff, rgba(124,247,255,.25));
+      box-shadow: 0 0 18px rgba(124,247,255,.45);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <div class="tag"><span class="dot" aria-hidden="true"></span>SPICA / Beat Diffusion</div>
+      <h1>仕様（Overview / CIBG v0.1）</h1>
+    </div>
+    <a class="btn" href="../index.html"><span class="dot" aria-hidden="true"></span>トップへ戻る</a>
+  </header>
+
+  <section>
+    <p>
+      SPICAは「白色ノイズ → 条件でノイズ除去」という拡散モデルの比喩を、学習なしのルールとスコアで実装して
+      8小節ループの <b>BeatSpec / MIDI</b> を生成するクリエイティブコースです。
+      このページではCIBG視点での要求とスコープをまとめています。
+    </p>
+  </section>
+
+  <section>
+    <h2>目次</h2>
+    <ul>
+      <li>プロジェクト概要（C）</li>
+      <li>インプットの定義（I）</li>
+      <li>生成の流れ（B）</li>
+      <li>ガードレールと評価（G）</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>進め方</h2>
+    <p>概要を把握したら、設計と実装のドキュメントへ進んでください。</p>
+    <div class="links">
+      <a class="btn" href="design.html"><span class="dot" aria-hidden="true"></span>設計（Design）</a>
+      <a class="btn" href="implement.html"><span class="dot" aria-hidden="true"></span>実装（Implement）</a>
+    </div>
+  </section>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="color-scheme" content="dark" />
   <title>Python Training | Space Adventure</title>
-  <meta
+    <meta
     name="description"
-    content="Training Course @Space Adventure — GitHub(PR)で進める、冒険感のあるPythonトレーニング。VEGA / ALTAIR / DENEB の各コースへ最短でアクセス。"
+    content="Training Course @Space Adventure — GitHub(PR)で進める、冒険感のあるPythonトレーニング。VEGA / ALTAIR / DENEB / SPICA の各コースへ最短でアクセス。"
   />
 
   <style>
@@ -513,6 +513,19 @@
       background: radial-gradient(circle at 30% 30%, var(--accent2), rgba(167,139,250,.20));
       box-shadow: 0 0 18px rgba(167,139,250,.38);
     }
+    /* Highlight for NEW course */
+    .tag.hot .chip{
+      background: radial-gradient(circle at 30% 30%, var(--hot), rgba(255,94,168,.20));
+      box-shadow: 0 0 18px rgba(255,94,168,.45);
+    }
+    .course.spica{
+      border-color: rgba(255,94,168,.22);
+    }
+    .course.spica::before{
+      background: radial-gradient(640px 280px at 20% 25%, rgba(255,94,168,.14), transparent 62%),
+                  radial-gradient(540px 260px at 80% 35%, rgba(124,247,255,.14), transparent 62%),
+                  radial-gradient(520px 220px at 55% 90%, rgba(167,139,250,.10), transparent 70%);
+    }
     .courseName h4{
       margin: 0;
       font-size: 22px;
@@ -940,10 +953,13 @@
                 <br />
                 「トレーニングしながら冒険を楽しむ」ための、活動感あるPythonトレーニングのホームです。
                 スマホでも見やすいレスポンシブ対応。
+                <br />
+                さらに <span class="kbd">SPICA</span>（Beat Diffusion）で、<b>"条件付き生成"</b> を実装するクリエイティブコースも追加。
               </p>
 
               <div class="heroActions">
                 <a class="btn primary" href="#courses"><span class="dot" aria-hidden="true"></span>コース一覧へ</a>
+                <a class="btn" href="#spica"><span class="dot" aria-hidden="true"></span>NEW: SPICA</a>
                 <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>進め方（GitHub/PR）</a>
                 <a class="btn" href="#faq"><span class="dot" aria-hidden="true"></span>よくある質問</a>
               </div>
@@ -952,6 +968,7 @@
                 <span class="pill"><span class="spark" aria-hidden="true"></span>VEGA: <b>1日1時間 / 7日</b></span>
                 <span class="pill"><span class="spark" aria-hidden="true"></span>ALTAIR: <b>1日2時間 / 3ヶ月</b></span>
                 <span class="pill"><span class="spark" aria-hidden="true"></span>DENEB: <b>1日30分 / 7日</b></span>
+                <span class="pill"><span class="spark" aria-hidden="true"></span>SPICA: <b>1日1時間 / 14日</b></span>
               </div>
             </div>
           </div>
@@ -971,9 +988,10 @@
               <ul>
                 <li><span class="kbd">VEGA</span>：基礎〜全般を短期で攻略</li>
                 <li><span class="kbd">ALTAIR</span>：長期でじっくり鍛える</li>
+                <li><a href="btd/overview.html"><span class="kbd">SPICA</span>：Beat Diffusionで“条件付き生成”をつくる（仕様→設計→実装）</a></li>
                 <li><span class="kbd">DENEB</span>：QR→CSVを型ファーストで作る（1週間）</li>
                 <li><a href="qr/samples.html"><span class="kbd">DENEB Samples</span>：テスト用サンプルQR（フォーマット別）</a></li>
-                <li>各コースは <span class="kbd">scope / index / overview / spec</span> へ（DENEBは <span class="kbd">index / overview / spec / samples</span>）</li>
+                <li>各コースは <span class="kbd">scope / index / overview / spec</span> へ（DENEBは <span class="kbd">index / overview / spec / samples</span>、SPICAは <span class="kbd">overview / design / implement</span>）</li>
               </ul>
             </div>
           </aside>
@@ -985,7 +1003,7 @@
         <div class="secTitle">
           <div>
             <h3>コース</h3>
-            <p>画像メモにある構成（VEGA / ALTAIR / DENEB）を、そのまま“かっこよく”整理してリンク化しています。</p>
+            <p>画像メモにある構成（VEGA / ALTAIR / DENEB / SPICA）を、そのまま“かっこよく”整理してリンク化しています。</p>
           </div>
         </div>
 
@@ -1145,6 +1163,75 @@
             <div class="courseFoot">
               <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>提出フローを見る</a>
               <a class="btn primary" href="bt30/index.html"><span class="dot" aria-hidden="true"></span>ALTAIRを開始</a>
+            </div>
+          </article>
+
+          <!-- SPICA -->
+          <article class="course spica" id="spica" aria-label="コース SPICA">
+            <div class="courseHead">
+              <div class="courseName">
+                <span class="tag hot"><span class="chip" aria-hidden="true"></span>NEW コース SPICA</span>
+                <h4>SPICA</h4>
+                <p>
+                  「拡散＝白色ノイズ→条件でノイズ除去」の比喩を、<span class="kbd">学習なし</span>のルール＆スコアで再現。
+                  8小節ループの <span class="kbd">BeatSpec</span> と <span class="kbd">MIDI</span> を生成する、クリエイティブ実装コースです。
+                  <br />
+                  仕様 → 設計 → Codex向けIssue分解まで揃っているので、最短で “動く生成” に到達できます。
+                </p>
+              </div>
+
+              <div class="courseMeta">
+                <div><b>学習目安</b></div>
+                <div>1日1時間 / 14日</div>
+              </div>
+            </div>
+
+            <div class="links" role="list">
+              <a class="linkCard" role="listitem" href="btd/overview.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M12 6v12M6 12h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M4 8c3-4 13-4 16 0M4 16c3 4 13 4 16 0" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>仕様（Overview / CIBG v0.1）</b>
+                  <small>btd/overview.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="btd/design.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M4 6h16M4 12h16M4 18h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M7 6v12M17 6v12" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity=".65"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>設計（Design / Pipeline v0.1）</b>
+                  <small>btd/design.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="btd/implement.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M8 9 5 12l3 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M16 9l3 3-3 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 19 14 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>実装（Implement / Codex Issue設計）</b>
+                  <small>btd/implement.html</small>
+                </div>
+              </a>
+            </div>
+
+            <div class="courseFoot">
+              <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>提出フローを見る</a>
+              <a class="btn" href="btd/design.html"><span class="dot" aria-hidden="true"></span>設計から読む</a>
+              <a class="btn primary" href="btd/overview.html"><span class="dot" aria-hidden="true"></span>SPICAを開始</a>
             </div>
           </article>
           
@@ -1356,6 +1443,18 @@
           <p>
             このページは星空（Canvas）を軽くアニメーションしています。
             さらに加えるなら「スクロール連動の演出」「コース選択で内容が切り替わるUI」などが相性◎です。
+          </p>
+        </details>
+
+        <details>
+          <summary>
+            SPICA（Beat Diffusion）ってどんなコース？
+            <span class="chev" aria-hidden="true">▾</span>
+          </summary>
+          <p>
+            <span class="kbd">SPICA</span> は、拡散モデルの比喩（白色ノイズ→条件でノイズ除去）を“学習なし”で再現し、
+            条件JSONから <span class="kbd">8小節ループ</span>の <span class="kbd">BeatSpec</span> / <span class="kbd">MIDI</span> を生成するプロジェクト型コースです。
+            まずは <a href="#spica">コースSPICA</a> から、<a href="btd/overview.html">仕様</a>→<a href="btd/design.html">設計</a>→<a href="btd/implement.html">実装（Codex）</a> の順で進めるとスムーズです。
           </p>
         </details>
 


### PR DESCRIPTION
## Summary
- highlight the new SPICA course in the hero content, shortcuts, and course list with updated CTA and learning pace notes
- add a dedicated SPICA course card and FAQ entry while refreshing descriptions to include the new track
- create SPICA overview, design, and implement stub pages under btd/ so links resolve

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d41e458a08333af308c6e9fe05a52)