### PR TITLE
Add SPICA spec link to course overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -988,10 +988,10 @@
               <ul>
                 <li><span class="kbd">VEGA</span>：基礎〜全般を短期で攻略</li>
                 <li><span class="kbd">ALTAIR</span>：長期でじっくり鍛える</li>
-                <li><a href="btd/overview.html"><span class="kbd">SPICA</span>：Beat Diffusionで“条件付き生成”をつくる（仕様→設計→実装）</a></li>
+                <li><a href="btd/overview.html"><span class="kbd">SPICA</span>：Beat Diffusionで“条件付き生成”をつくる（仕様→動くイメージ→設計→実装）</a></li>
                 <li><span class="kbd">DENEB</span>：QR→CSVを型ファーストで作る（1週間）</li>
                 <li><a href="qr/samples.html"><span class="kbd">DENEB Samples</span>：テスト用サンプルQR（フォーマット別）</a></li>
-                <li>各コースは <span class="kbd">scope / index / overview / spec</span> へ（DENEBは <span class="kbd">index / overview / spec / samples</span>、SPICAは <span class="kbd">overview / design / implement</span>）</li>
+                <li>各コースは <span class="kbd">scope / index / overview / spec</span> へ（DENEBは <span class="kbd">index / overview / spec / samples</span>、SPICAは <span class="kbd">overview / spec / design / implement</span>）</li>
               </ul>
             </div>
           </aside>
@@ -1176,7 +1176,7 @@
                   「拡散＝白色ノイズ→条件でノイズ除去」の比喩を、<span class="kbd">学習なし</span>のルール＆スコアで再現。
                   8小節ループの <span class="kbd">BeatSpec</span> と <span class="kbd">MIDI</span> を生成する、クリエイティブ実装コースです。
                   <br />
-                  仕様 → 設計 → Codex向けIssue分解まで揃っているので、最短で “動く生成” に到達できます。
+                  仕様 → 動くイメージ → 設計 → Codex向けIssue分解まで揃っているので、最短で “動く生成” に到達できます。
                 </p>
               </div>
 
@@ -1197,6 +1197,20 @@
                 <div class="t">
                   <b>仕様（Overview / CIBG v0.1）</b>
                   <small>btd/overview.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="btd/spec.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M8 12h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M12 8v8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>動くイメージ（Spec / Demo）</b>
+                  <small>btd/spec.html</small>
                 </div>
               </a>
 
@@ -1454,7 +1468,7 @@
           <p>
             <span class="kbd">SPICA</span> は、拡散モデルの比喩（白色ノイズ→条件でノイズ除去）を“学習なし”で再現し、
             条件JSONから <span class="kbd">8小節ループ</span>の <span class="kbd">BeatSpec</span> / <span class="kbd">MIDI</span> を生成するプロジェクト型コースです。
-            まずは <a href="#spica">コースSPICA</a> から、<a href="btd/overview.html">仕様</a>→<a href="btd/design.html">設計</a>→<a href="btd/implement.html">実装（Codex）</a> の順で進めるとスムーズです。
+            まずは <a href="#spica">コースSPICA</a> から、<a href="btd/overview.html">仕様</a>→<a href="btd/spec.html">動くイメージ</a>→<a href="btd/design.html">設計</a>→<a href="btd/implement.html">実装（Codex）</a> の順で進めるとスムーズです。
           </p>
         </details>
 


### PR DESCRIPTION
## Summary
- add the SPICA "動くイメージ" (Spec) link alongside other course navigation cards
- update quick links and FAQ text so SPICA steps include the new spec/demo stage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d8ac282a483338441dc47107c9cd6)