### PR TITLE
Add RIGEL issue link to training index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1250,6 +1250,20 @@
                   <small>ec/spec.html</small>
                 </div>
               </a>
+
+              <a class="linkCard" role="listitem" href="ec/issue.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M7 6h10M7 10h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M6 4a2 2 0 0 1 2-2h8l4 4v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" stroke="currentColor" stroke-width="2"/>
+                    <path d="M15 18h4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>RIGEL実装Issueセット</b>
+                  <small>ec/issue.html</small>
+                </div>
+              </a>
             </div>
 
             <div class="courseFoot">


### PR DESCRIPTION
## Summary
- add a new link card for the RIGEL course pointing to ec/issue.html
- describe it as the issue set for implementing the RIGEL course

## Testing
- not run (static change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f5f46e13c8333a142fc2f091e6cf2)