### PR TITLE
Align VEGA pages with top-page theme

### DIFF
--- a/bt7/index.html
+++ b/bt7/index.html
@@ -3,184 +3,26 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BEAT楽器トレーニング計画 - ポップアートスタイル</title>
-    <link rel="stylesheet" href="pop3_style.css">
-    <!-- KaTeX CSS -->
+    <title>BEAT楽器トレーニング計画 - VEGAコース</title>
+    <link rel="stylesheet" href="vega_theme.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-    <!-- 追加のカラフルスタイル -->
-    <style>
-        :root {
-            /* カラーパレット - ポップアート風 */
-            --pop-primary: #ff4081;
-            --pop-secondary: #1e90ff;
-            --pop-accent: #ffdd57;
-            --pop-dark: #333333;
-            --pop-light: #ffffff;
-            --pop-success: #00c853;
-            --pop-warning: #ff9100;
-            --pop-danger: #ff1744;
-            --pop-info: #00b0ff;
-            
-            /* コントラスト確保のための明るさ/暗さ調整 */
-            --text-on-dark: #ffffff;
-            --text-on-light: #333333;
-            --text-on-accent: #333333;
-        }
-        
-        /* カラーテーマを適用 */
-        body {
-            background: linear-gradient(135deg, var(--pop-accent) 0%, #ffcc00 100%);
-            color: var(--pop-dark);
-            line-height: 1.6;
-        }
-        
-        .container {
-            background-color: var(--pop-light);
-            border: 5px solid var(--pop-primary);
-        }
-        
-        h1, h2, h3, h4 {
-            color: var(--pop-primary);
-        }
-        
-        /* カラフルなセクション */
-        .section-milestone {
-            background: linear-gradient(90deg, var(--pop-info) 0%, #00e5ff 100%);
-            color: var(--text-on-dark);
-            padding: 15px;
-            border-radius: 10px;
-            margin: 20px 0;
-            border-left: 8px solid var(--pop-secondary);
-        }
-        
-        .section-issue {
-            background: linear-gradient(90deg, #f8f9fa 0%, #ffffff 100%);
-            padding: 20px;
-            border-radius: 10px;
-            margin: 25px 0;
-            border: 3px solid var(--pop-secondary);
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-        }
-        
-        .section-issue:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
-            border-color: var(--pop-primary);
-        }
-        
-        .issue-label {
-            display: inline-block;
-            padding: 5px 12px;
-            margin: 0 5px 5px 0;
-            border-radius: 20px;
-            font-weight: bold;
-            font-size: 0.9rem;
-            color: white;
-            text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
-        }
-        
-        .label-epic { background-color: var(--pop-primary); }
-        .label-feature { background-color: var(--pop-success); }
-        .label-bug { background-color: var(--pop-danger); }
-        .label-test { background-color: var(--pop-warning); }
-        .label-docs { background-color: var(--pop-info); }
-        .label-refactor { background-color: #9c27b0; }
-        
-        /* B1-B10 ラベル用の色 */
-        .label-b1 { background-color: #ff5722; }
-        .label-b2 { background-color: #ff9800; }
-        .label-b3 { background-color: #ffc107; }
-        .label-b4 { background-color: #8bc34a; }
-        .label-b5 { background-color: #4caf50; }
-        .label-b6 { background-color: #009688; }
-        .label-b7 { background-color: #00bcd4; }
-        .label-b8 { background-color: #2196f3; }
-        .label-b9 { background-color: #3f51b5; }
-        .label-b10 { background-color: #673ab7; }
-        .label-good-first { background-color: #e91e63; }
-        
-        /* テーブルスタイル */
-        table {
-            border: 3px solid var(--pop-dark);
-            margin: 20px 0;
-            background-color: white;
-        }
-        
-        th {
-            background-color: var(--pop-primary);
-            color: var(--text-on-dark);
-            font-weight: bold;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-        }
-        
-        td {
-            border-color: var(--pop-dark);
-        }
-        
-        tr:nth-child(even) {
-            background-color: rgba(255, 64, 129, 0.1);
-        }
-        
-        /* コードブロックのスタイル */
-        pre {
-            background: linear-gradient(90deg, #2d3436 0%, #1a1a1a 100%);
-            color: #00ff9d;
-            border: 2px solid var(--pop-secondary);
-            border-left: 8px solid var(--pop-secondary);
-        }
-        
-        /* 数式コンテナ */
-        .math-container {
-            background-color: rgba(255, 255, 255, 0.9);
-            padding: 15px;
-            border-radius: 8px;
-            margin: 15px 0;
-            border: 2px dashed var(--pop-primary);
-        }
-        
-        /* ヘッダーのアニメーション強化 */
-        header {
-            background: linear-gradient(90deg, var(--pop-primary) 0%, #ff0066 100%);
-            letter-spacing: 2px;
-        }
-        
-        /* フッターのスタイル */
-        .footer {
-            background: linear-gradient(90deg, var(--pop-primary) 0%, #ff0066 100%);
-            font-weight: bold;
-            letter-spacing: 1px;
-        }
-        
-        /* レスポンシブ調整 */
-        @media (max-width: 768px) {
-            .section-issue {
-                padding: 15px;
-                margin: 15px 0;
-            }
-            
-            .issue-label {
-                font-size: 0.8rem;
-                padding: 4px 8px;
-            }
-        }
-    </style>
 </head>
 <body>
-    <header>
-        GitHub Issues Backlog: Python「BEAT楽器」(ミニ・ドラムマシン)
+  <div class="wrap">
+    <header class="page-header">
+      <p class="eyebrow">VEGA COURSE</p>
+      <h1>BEAT楽器トレーニング計画</h1>
+      <p class="lede">GitHub Issues Backlog: Python「BEAT楽器」（ミニ・ドラムマシン）— トップページのスペース感に合わせたダークテーマで整理しました。</p>
     </header>
-    
-    <div class="container">
-        <h1>BEAT楽器トレーニング計画</h1>
-        
+
+    <main class="flow">
+      <section class="panel flow">
         <div class="math-container">
-            <p><strong>時間解像度の計算式:</strong></p>
-            <p>1ステップの秒数: \(\text{step\_sec} = \frac{60}{\text{bpm} \times 4}\)</p>
-            <p>1小節の秒数: \(\text{bar\_sec} = 16 \times \text{step\_sec} = \frac{60 \times 16}{\text{bpm} \times 4} = \frac{240}{\text{bpm}}\)</p>
+          <p><strong>時間解像度の計算式:</strong></p>
+          <p>1ステップの秒数: \(\text{step\_sec} = \frac{60}{\text{bpm} \times 4}\)</p>
+          <p>1小節の秒数: \(\text{bar\_sec} = 16 \times \text{step\_sec} = \frac{60 \times 16}{\text{bpm} \times 4} = \frac{240}{\text{bpm}}\)</p>
         </div>
-        
+
         <div class="section-milestone">
             <h2>共通仕様（全Issue共通の契約）</h2>
             
@@ -207,50 +49,52 @@
                 <li><code>OutputType</code>（出力型）</li>
             </ul>
         </div>
-        
-        <h2>入力ファイル仕様（MVP）</h2>
-        <p>例（最小）:</p>
-        <pre><code>bpm=120
+
+        <div class="panel flow">
+          <h2>入力ファイル仕様（MVP）</h2>
+          <p>例（最小）:</p>
+          <pre><code>bpm=120
 K:x---x---x---x---
 S:----x-------x---
 H:x-x-x-x-x-x-x-x-</code></pre>
-        
-        <h3>ルール（MVPの確定仕様）</h3>
-        <ul>
+
+          <h3>ルール（MVPの確定仕様）</h3>
+          <ul>
             <li><code>bpm=&lt;int&gt;</code> が1行（先頭推奨、ただし順不同でもよい）</li>
             <li>トラック行：<code>&lt;InstrumentID&gt;:&lt;Pattern&gt;</code>
-                <ul>
-                    <li><code>InstrumentID</code> は <code>K</code>, <code>S</code>, <code>H</code> を <strong>必須対応</strong>（Kick/Snare/Hat）</li>
-                    <li><code>Pattern</code> は <strong>長さ16固定</strong></li>
-                    <li>文字は <code>x</code>（ヒット）と <code>-</code>（休符）のみ（MVP）</li>
-                </ul>
+              <ul>
+                <li><code>InstrumentID</code> は <code>K</code>, <code>S</code>, <code>H</code> を <strong>必須対応</strong>（Kick/Snare/Hat）</li>
+                <li><code>Pattern</code> は <strong>長さ16固定</strong></li>
+                <li>文字は <code>x</code>（ヒット）と <code>-</code>（休符）のみ（MVP）</li>
+              </ul>
             </li>
             <li>空行は無視してよい</li>
             <li>余計な空白は左右トリムしてよい</li>
-        </ul>
-        
-        <h2>時間解像度（MVP）</h2>
-        <ul>
+          </ul>
+
+          <h2>時間解像度（MVP）</h2>
+          <ul>
             <li>16ステップ = 1小節（16分音符相当）</li>
             <li>1ステップ秒数：<code>step_sec = 60 / bpm / 4</code>（資料の定義を採用）</li>
-        </ul>
-        
-        <h2>波形（MVP）</h2>
-        <ul>
+          </ul>
+
+          <h2>波形（MVP）</h2>
+          <ul>
             <li>内部表現：<code>list[float]</code>（-1.0〜1.0）</li>
             <li>WAV出力：16bit PCM（mono）</li>
-        </ul>
-        
-        <h2>エラー戦略（MVP）</h2>
-        <ul>
+          </ul>
+
+          <h2>エラー戦略（MVP）</h2>
+          <ul>
             <li>入力不正は <strong>例外で落とす</strong>
-                <ul>
-                    <li><code>ValueError</code> を基本</li>
-                    <li>メッセージは「どの行の何がダメか」を含める</li>
-                </ul>
+              <ul>
+                <li><code>ValueError</code> を基本</li>
+                <li>メッセージは「どの行の何がダメか」を含める</li>
+              </ul>
             </li>
-        </ul>
-        
+          </ul>
+        </div>
+
         <div class="section-milestone">
             <h2>Milestones（推奨）</h2>
             <ul>
@@ -262,14 +106,28 @@ H:x-x-x-x-x-x-x-x-</code></pre>
                 <li><strong>M5: Tests & Docs</strong>（品質/使い方）</li>
             </ul>
         </div>
-        
+
         <div class="section-milestone">
             <h2>Labels（推奨）</h2>
-            <ul>
-                <li><span class="issue-label label-epic">epic</span>, <span class="issue-label label-feature">feature</span>, <span class="issue-label label-bug">bug</span>, <span class="issue-label label-test">test</span>, <span class="issue-label label-docs">docs</span>, <span class="issue-label label-refactor">refactor</span></li>
-                <li><span class="issue-label label-b1">B1</span>〜<span class="issue-label label-b10">B10</span>（等価クラス番号をラベル化）</li>
-                <li><span class="issue-label label-good-first">good first issue</span>（初学者向け）</li>
-            </ul>
+            <div class="label-set">
+                <span class="issue-label label-epic">epic</span>
+                <span class="issue-label label-feature">feature</span>
+                <span class="issue-label label-bug">bug</span>
+                <span class="issue-label label-test">test</span>
+                <span class="issue-label label-docs">docs</span>
+                <span class="issue-label label-refactor">refactor</span>
+                <span class="issue-label label-b1">B1</span>
+                <span class="issue-label label-b2">B2</span>
+                <span class="issue-label label-b3">B3</span>
+                <span class="issue-label label-b4">B4</span>
+                <span class="issue-label label-b5">B5</span>
+                <span class="issue-label label-b6">B6</span>
+                <span class="issue-label label-b7">B7</span>
+                <span class="issue-label label-b8">B8</span>
+                <span class="issue-label label-b9">B9</span>
+                <span class="issue-label label-b10">B10</span>
+                <span class="issue-label label-good-first">good first issue</span>
+            </div>
         </div>
         
         <h1>Issueテンプレ（コピペ用）</h1>
@@ -311,7 +169,7 @@ H:x-x-x-x-x-x-x-x-</code></pre>
                 <li><code>python -m unittest</code> が通る（主要機能）</li>
             </ul>
         </div>
-        
+
         <!-- BEAT-01 Issue -->
         <div class="section-issue character">
             <h2>BEAT-01: リポジトリ骨格とモジュール構成を作る</h2>
@@ -353,7 +211,7 @@ H:x-x-x-x-x-x-x-x-</code></pre>
                 <li>CLI実行の入口が存在する</li>
             </ul>
         </div>
-        
+
         <!-- BEAT-02 Issue -->
         <div class="section-issue character">
             <h2>BEAT-02: ドメインモデル定義（Song / Hit / 定数）</h2>
@@ -950,10 +808,10 @@ H:x-x-x-x-x-x-x-x-</code></pre>
             <p>イベント時間: \(t_{\text{event}} = n_{\text{step}} \times t_{\text{step}}\)</p>
             <p>サンプル位置: \(s_{\text{pos}} = \lfloor t_{\text{event}} \times f_s \rfloor\)</p>
         </div>
-    </div>
+    </main>
     
     <div class="footer">
-        BEAT楽器トレーニング計画 - ポップアートスタイル版 | 色管理アーキテクチャ採用 | KaTeX対応
+        BEAT楽器トレーニング計画 - VEGAコース | ダークスペーストーンで統一 | KaTeX対応
     </div>
     
     <!-- KaTeX JS -->
@@ -972,5 +830,6 @@ H:x-x-x-x-x-x-x-x-</code></pre>
             });
         });
     </script>
+  </div>
 </body>
 </html>

--- a/bt7/overview.html
+++ b/bt7/overview.html
@@ -4,329 +4,45 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BEAT楽器トレーニング計画 - 型を選択する工学</title>
-    <link rel="stylesheet" href="pop3_style.css">
-    <!-- KaTeX CSS -->
+    <link rel="stylesheet" href="vega_theme.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-    <!-- 改善された色管理アーキテクチャ -->
     <style>
-        /* ============================================
-           カラーマネジメントシステム - コントラスト保証
-           ============================================ */
-        :root {
-            /* プライマリーカラーパレット - 明るい順に定義 */
-            --color-primary-100: #ffebf3;
-            --color-primary-200: #ffb8d9;
-            --color-primary-300: #ff85bf;
-            --color-primary-400: #ff4081; /* メイン */
-            --color-primary-500: #e6006c;
-            --color-primary-600: #b30054;
-            --color-primary-700: #80003d;
-            
-            /* セカンダリーカラーパレット - 明るい順に定義 */
-            --color-secondary-100: #fff9e6;
-            --color-secondary-200: #ffed99;
-            --color-secondary-300: #ffe14d;
-            --color-secondary-400: #ffdd57; /* メイン */
-            --color-secondary-500: #e6c74e;
-            --color-secondary-600: #b39d3d;
-            --color-secondary-700: #80712c;
-            
-            /* アクセントカラーパレット */
-            --color-accent-blue-100: #e6f2ff;
-            --color-accent-blue-400: #1e90ff;
-            --color-accent-blue-700: #0066cc;
-            
-            --color-accent-green-100: #e6ffe6;
-            --color-accent-green-400: #32cd32;
-            --color-accent-green-700: #228b22;
-            
-            --color-accent-orange-100: #fff5e6;
-            --color-accent-orange-400: #ffa500;
-            --color-accent-orange-700: #cc8400;
-            
-            --color-accent-purple-100: #f0e6ff;
-            --color-accent-purple-400: #9370db;
-            --color-accent-purple-700: #6a5acd;
-            
-            --color-accent-red-100: #ffe6e6;
-            --color-accent-red-400: #ff6347;
-            --color-accent-red-700: #cc4c38;
-            
-            /* ニュートラルカラーパレット */
-            --color-neutral-white: #ffffff;
-            --color-neutral-light: #f8f9fa;
-            --color-neutral-gray: #6c757d;
-            --color-neutral-dark: #343a40;
-            --color-neutral-black: #222222;
-            
-            /* テキストカラーパレット - コントラスト保証用 */
-            --text-on-light: #222222;    /* 明背景用の暗い文字 */
-            --text-on-dark: #ffffff;     /* 暗背景用の明るい文字 */
-            --text-on-primary: #ffffff;  /* プライマリ背景用 */
-            --text-on-secondary: #222222;/* セカンダリ背景用 */
-            
-            /* セーフカラーペア - 背景と文字の組み合わせを保証 */
-            --safe-bg-light: var(--color-neutral-white);
-            --safe-text-light: var(--text-on-light);
-            
-            --safe-bg-dark: var(--color-neutral-dark);
-            --safe-text-dark: var(--text-on-dark);
-            
-            --safe-bg-primary: var(--color-primary-400);
-            --safe-text-primary: var(--text-on-primary);
-            
-            --safe-bg-secondary: var(--color-secondary-400);
-            --safe-text-secondary: var(--text-on-secondary);
-            
-            /* シャドウ */
-            --shadow-default: 0 0 20px rgba(0, 0, 0, 0.2);
-            --shadow-heavy: 0 0 30px rgba(0, 0, 0, 0.4);
-        }
-        
-        /* コントラストチェック用ユーティリティクラス */
-        .contrast-check {
-            /* 将来的にJavaScriptで動的にチェックするためのフック */
-            background-color: var(--current-bg);
-            color: var(--current-text);
-        }
-        
-        /* ============================================
-           セクションスタイル - コントラスト保証付き
-           ============================================ */
-        .section-1 {
-            /* 背景: 青系の明るめの色、文字: 白 */
-            background-color: var(--color-accent-blue-400);
-            color: var(--text-on-dark);
-            border: 3px solid var(--color-accent-blue-700);
-        }
-        
-        .section-2 {
-            /* 背景: 緑系、文字: 白 */
-            background-color: var(--color-accent-green-400);
-            color: var(--text-on-dark);
-            border: 3px solid var(--color-accent-green-700);
-        }
-        
-        .section-3 {
-            /* 背景: 明るい黄色、文字: 黒 */
-            background-color: var(--color-secondary-400);
-            color: var(--text-on-light);
-            border: 3px solid var(--color-secondary-600);
-        }
-        
-        .section-4 {
-            /* 背景: 紫系、文字: 白 */
-            background-color: var(--color-accent-purple-400);
-            color: var(--text-on-dark);
-            border: 3px solid var(--color-accent-purple-700);
-        }
-        
-        .section-5 {
-            /* 背景: 赤系、文字: 白 */
-            background-color: var(--color-accent-red-400);
-            color: var(--text-on-dark);
-            border: 3px solid var(--color-accent-red-700);
-        }
-        
-        /* セクション内の見出しもコントラスト保証 */
-        .section-1 h2, .section-1 h3, .section-1 h4 {
-            color: var(--color-neutral-white);
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
-        }
-        
-        .section-2 h2, .section-2 h3, .section-2 h4 {
-            color: var(--color-neutral-white);
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
-        }
-        
-        .section-3 h2, .section-3 h3, .section-3 h4 {
-            color: var(--color-neutral-black);
-            text-shadow: 1px 1px 2px rgba(255, 255, 255, 0.5);
-        }
-        
-        .section-4 h2, .section-4 h3, .section-4 h4 {
-            color: var(--color-neutral-white);
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
-        }
-        
-        .section-5 h2, .section-5 h3, .section-5 h4 {
-            color: var(--color-neutral-white);
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
-        }
-        
-        /* セクション内のリンクもコントラスト保証 */
-        .section-1 a {
-            color: var(--color-secondary-400);
-            text-decoration: underline;
-        }
-        
-        .section-2 a {
-            color: var(--color-secondary-400);
-            text-decoration: underline;
-        }
-        
-        .section-3 a {
-            color: var(--color-accent-blue-700);
-            text-decoration: underline;
-        }
-        
-        .section-4 a {
-            color: var(--color-secondary-400);
-            text-decoration: underline;
-        }
-        
-        .section-5 a {
-            color: var(--color-secondary-400);
-            text-decoration: underline;
-        }
-        
-        /* セクション共通スタイル */
         .training-section {
-            border-radius: 15px;
-            padding: 25px;
-            margin-bottom: 30px;
-            box-shadow: var(--shadow-default);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
-        
-        .training-section:hover {
-            transform: translateY(-5px);
-            box-shadow: var(--shadow-heavy);
-        }
-        
-        /* ============================================
-           テーブルスタイル - コントラスト保証付き
-           ============================================ */
-        table {
-            background-color: var(--color-neutral-white);
-            border: 3px solid var(--color-neutral-black);
-        }
-        
-        th {
-            background-color: var(--color-primary-400);
-            color: var(--text-on-primary);
-            font-weight: bold;
-            text-align: center;
-            padding: 12px;
-        }
-        
-        td {
-            background-color: var(--color-neutral-white);
-            color: var(--text-on-light);
-            padding: 10px;
-            border: 1px solid var(--color-neutral-gray);
-        }
-        
-        tr:nth-child(even) td {
-            background-color: var(--color-neutral-light);
-        }
-        
-        tr:hover td {
-            background-color: var(--color-primary-100);
-        }
-        
-        /* ============================================
-           コードブロック - 明るい文字と暗い背景
-           ============================================ */
-        pre {
-            background-color: var(--color-neutral-black);
-            color: #00ff00; /* 高い可読性の緑 */
-            border-left: 5px solid var(--color-primary-400);
-            font-family: 'Courier New', monospace;
-            font-weight: bold;
-            padding: 15px;
-            overflow-x: auto;
-        }
-        
-        /* 数式コンテナ - 明るい背景に暗い文字 */
-        .math-container {
-            background-color: var(--color-neutral-white);
-            color: var(--text-on-light);
-            border: 2px dashed var(--color-primary-400);
-            border-radius: 10px;
+            border-radius: var(--r);
             padding: 20px;
-            margin: 20px 0;
-            text-align: center;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(0, 0, 0, 0.32);
+            box-shadow: var(--shadow);
         }
-        
-        /* リストアイテムの可読性向上 */
-        li {
-            margin-bottom: 8px;
-            line-height: 1.6;
+
+        .training-section + .training-section {
+            margin-top: 18px;
         }
-        
-        /* 引用ブロックの可読性向上 */
-        blockquote {
-            background-color: rgba(255, 255, 255, 0.9);
-            color: var(--text-on-light);
-            border-left: 5px solid var(--color-primary-400);
-            padding: 15px;
-            margin: 20px 0;
-            border-radius: 0 10px 10px 0;
+
+        .training-section h2 {
+            margin-top: 0;
         }
-        
-        /* レスポンシブ調整 */
-        @media (max-width: 768px) {
-            .training-section {
-                padding: 15px;
-            }
-            
-            .math-container {
-                padding: 10px;
-                overflow-x: auto;
-            }
-            
-            table {
-                font-size: 0.9em;
-            }
+
+        .katex-display {
+            font-size: 1.1em;
+            color: var(--text);
         }
-        
-        /* ヘッダー強化 - コントラスト保証 */
-        header {
-            background: linear-gradient(135deg, var(--color-primary-400), var(--color-primary-600));
-            color: var(--text-on-primary);
-            border-bottom: 5px solid var(--color-neutral-black);
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-        }
-        
-        /* フッター強化 - コントラスト保証 */
-        .footer {
-            background: linear-gradient(135deg, var(--color-primary-400), var(--color-primary-600));
-            color: var(--text-on-primary);
-            border-top: 5px solid var(--color-neutral-black);
-            font-weight: bold;
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-        }
-        
-        /* コンテナの背景を明るくして文字を暗く */
-        .container {
-            background-color: var(--color-neutral-white);
-            color: var(--text-on-light);
-        }
-        
-        /* ボディの背景もコントラスト保証 */
-        body {
-            background-color: var(--color-secondary-400);
-            color: var(--text-on-secondary);
-        }
-        
-        /* KaTeX 数式のコントラスト保証 */
-        .katex {
-            color: var(--text-on-light) !important;
-        }
-        
-        .math-container .katex {
-            color: inherit !important;
+
+        .table-wrap {
+            overflow-x: auto;
         }
     </style>
 </head>
 <body>
-    <header>
+  <div class="wrap">
+    <header class="page-header">
+        <p class="eyebrow">VEGA COURSE</p>
         <h1>🎵 BEAT楽器トレーニング計画 🥁</h1>
-        <p>「プログラミング＝型を選択する工学」の実践</p>
+        <p class="lede">トップページの宇宙感に合わせたダークトーンに統一し、「プログラミング＝型を選択する工学」の学習導線を整理しました。</p>
     </header>
 
-    <div class="container">
+    <main class="flow">
+        <section class="panel flow">
         <div class="training-section section-1">
             <h2>前回の設計（論文の枠組み）</h2>
             <div class="math-container">
@@ -411,7 +127,8 @@
             <h3>✅ (A(S))：ビート楽器で身につける「型選択パターン」10クラス</h3>
             <p>（= 7時間で"被覆"したい離散条件集合。各クラスに代表演習を1つ置きます）</p>
             
-            <table>
+            <div class="table-scroll">
+                <table>
                 <thead>
                     <tr>
                         <th>ID</th>
@@ -504,7 +221,8 @@
                         <td>parse→validate→schedule→render→export を分割して完成</td>
                     </tr>
                 </tbody>
-            </table>
+                </table>
+            </div>
             <blockquote>
                 <p>この (A(S)) を、1日1時間×7日でできるだけ少ない演習で"被覆"する（論文の set cover / hitting set の発想）＝今回のメニュー設計です。</p>
             </blockquote>
@@ -656,11 +374,13 @@ H:x-x-x-x-x-x-x-x-</pre>
                 <li>どの型を選ぶかで、設計の"やりやすさ"が変わる<br>→ ここがあなたの骨格そのもの</li>
             </ul>
         </div>
-    </div>
+        </section>
+    </main>
 
     <div class="footer">
-        <p>BEAT楽器トレーニング計画 &copy; 2023 - 「型を選択する工学」の実践</p>
+        <p>BEAT楽器トレーニング計画 — VEGAコース | 宇宙感ダークテーマに統一</p>
     </div>
+  </div>
 
     <!-- KaTeX JS -->
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8" crossorigin="anonymous"></script>

--- a/bt7/scope.html
+++ b/bt7/scope.html
@@ -7,284 +7,41 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" onload="renderMathInElement(document.body);"></script>
+    <link rel="stylesheet" href="vega_theme.css">
     <style>
-        /* ベースCSS - pop3_style.cssの内容 */
-        body {
-            font-family: 'Arial', sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #ffdd57; /* Bold pop art colors */
-            color: #333;
+        .scope-section {
+            border-radius: var(--r);
+            padding: 18px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(0, 0, 0, 0.32);
+            box-shadow: var(--shadow);
         }
 
-        header {
-            background-color: #ff4081;
-            color: white;
-            padding: 10px 0;
-            text-align: center;
-            position: relative;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
-            text-transform: uppercase;
-            font-weight: bold;
-            font-size: 2.5rem;
-            animation: glow 1.5s infinite alternate;
+        .scope-section + .scope-section {
+            margin-top: 18px;
         }
 
-        @media (max-width: 768px) {
-            header {
-                font-size: 1.8rem; /* Smaller font for mobile devices */
-            }
-        }
-
-        @keyframes glow {
-            from {
-                text-shadow: 0 0 10px #ff4081, 0 0 20px #ff4081;
-            }
-            to {
-                text-shadow: 0 0 30px #ff4081, 0 0 40px #ff4081;
-            }
-        }
-
-        .container {
-            max-width: 1000px;
-            margin: 20px auto;
-            padding: 20px;
-            background-color: white;
-            border-radius: 15px;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
-            animation: popEffect 1s ease-in-out;
-        }
-
-        @keyframes popEffect {
-            0% {
-                transform: scale(0.8);
-                opacity: 0.6;
-            }
-            100% {
-                transform: scale(1);
-                opacity: 1;
-            }
-        }
-
-        h2 {
-            color: #ff4081;
-            font-size: 2rem;
-            font-weight: bold;
-        }
-
-        a {
-            text-decoration: none;
-            color: #1e90ff;
-            font-weight: bold;
-            transition: all 0.3s ease;
-        }
-
-        a:hover {
-            text-decoration: underline;
-            color: #ff4081;
-            text-shadow: 0 0 5px #ff4081;
-        }
-
-        img {
-            width: 100%;
-            max-width: 400px;
-            height: auto;
-            display: block;
-            margin: 10px auto;
-            border-radius: 10px;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-        }
-
-        table {
-            border-collapse: collapse;
-            width: 100%;
-        }
-
-        th, td {
-            border: 2px solid black;
-            padding: 8px;
-            text-align: left;
-        }
-
-        pre {
-            background-color: #f4f4f4;
-            padding: 10px;
-            border-radius: 5px;
-            overflow-x: auto; /* Allow horizontal scrolling */
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            font-family: 'Courier New', Courier, monospace;
-            max-width: 100%; /* Ensure it fits within the container */
-            box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.2);
-        }
-
-        .footer {
-            text-align: center;
-            padding: 10px;
-            background-color: #ff4081;
-            color: white;
-            position: fixed;
-            bottom: 0;
-            width: 100%;
-        }
-
-        .character {
-            margin-bottom: 30px;
-            border: 3px solid #ff4081;
-            padding: 20px;
-            border-radius: 10px;
-            background: #ffdd57;
-            box-shadow: 5px 5px 15px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-        }
-
-        .character:hover {
-            transform: scale(1.05);
-            background-color: #ffcc00;
-            box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.2);
-        }
-
-        @media (max-width: 768px) {
-            .container {
-                width: 90%;
-            }
-        }
-
-        /* KaTeXの数式がはみ出ないようにするためのスタイル */
-        .katex {
-            font-size: 1.1em !important; /* 数式のフォントサイズを調整 */
-            overflow-x: auto; /* 横スクロールを許可 */
-            overflow-y: hidden; /* 縦スクロールは不要 */
-            max-width: 100%; /* コンテナ幅に合わせる */
-            white-space: nowrap; /* 数式が折り返されないようにする */
+        .scope-section h2 {
+            margin-top: 0;
         }
 
         .katex-display {
-            margin: 0.5em 0; /* 数式の上下の余白を調整 */
-            overflow-x: auto; /* 横スクロールを許可 */
-            max-width: 100%; /* コンテナ幅に合わせる */
-        }
-
-        /* 追加のカラフルなスタイル - 色管理アーキテクチャ */
-        :root {
-            --primary-bg: #ffdd57;
-            --secondary-bg: #ff4081;
-            --accent-1: #1e90ff;
-            --accent-2: #32cd32;
-            --accent-3: #ff6347;
-            --text-dark: #333333;
-            --text-light: #ffffff;
-            --card-bg: #ffffff;
-            --shadow-color: rgba(0, 0, 0, 0.2);
-        }
-
-        /* セクションごとの色分け */
-        .section-1 { background-color: rgba(255, 105, 180, 0.1); border-left: 5px solid #ff69b4; padding: 15px; margin: 20px 0; border-radius: 0 10px 10px 0; }
-        .section-2 { background-color: rgba(30, 144, 255, 0.1); border-left: 5px solid #1e90ff; padding: 15px; margin: 20px 0; border-radius: 0 10px 10px 0; }
-        .section-3 { background-color: rgba(50, 205, 50, 0.1); border-left: 5px solid #32cd32; padding: 15px; margin: 20px 0; border-radius: 0 10px 10px 0; }
-        .section-4 { background-color: rgba(255, 99, 71, 0.1); border-left: 5px solid #ff6347; padding: 15px; margin: 20px 0; border-radius: 0 10px 10px 0; }
-        .section-5 { background-color: rgba(138, 43, 226, 0.1); border-left: 5px solid #8a2be2; padding: 15px; margin: 20px 0; border-radius: 0 10px 10px 0; }
-
-        /* テーブルスタイルの強化 */
-        th {
-            background-color: var(--secondary-bg);
-            color: var(--text-light);
-            font-weight: bold;
-        }
-
-        tr:nth-child(even) {
-            background-color: rgba(255, 64, 129, 0.1);
-        }
-
-        tr:nth-child(odd) {
-            background-color: rgba(255, 221, 87, 0.2);
-        }
-
-        /* コードブロックのスタイル強化 */
-        pre code {
-            display: block;
-            padding: 15px;
-            border-radius: 8px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            font-weight: bold;
-        }
-
-        /* 数式コンテナのスタイル */
-        .math-container {
-            background-color: rgba(255, 255, 255, 0.9);
-            padding: 15px;
-            border-radius: 10px;
-            margin: 15px 0;
-            border: 2px dashed var(--accent-1);
-            text-align: center;
-        }
-
-        /* 日別カリキュラムのスタイル */
-        .day-card {
-            background-color: var(--card-bg);
-            border-radius: 12px;
-            padding: 20px;
-            margin: 20px 0;
-            box-shadow: 0 8px 16px var(--shadow-color);
-            border-top: 8px solid;
-            transition: transform 0.3s ease;
-        }
-
-        .day-card:hover {
-            transform: translateY(-5px);
-        }
-
-        .day-1 { border-top-color: #ff4081; }
-        .day-2 { border-top-color: #1e90ff; }
-        .day-3 { border-top-color: #32cd32; }
-        .day-4 { border-top-color: #ff6347; }
-        .day-5 { border-top-color: #8a2be2; }
-        .day-6 { border-top-color: #ffa500; }
-        .day-7 { border-top-color: #00ced1; }
-
-        .time-slot {
-            background-color: rgba(255, 64, 129, 0.2);
-            padding: 8px;
-            border-radius: 6px;
-            margin: 10px 0;
-            font-weight: bold;
-            color: var(--text-dark);
-        }
-
-        /* ヘッダーナビゲーション */
-        .nav-container {
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 10px;
-            margin: 20px 0;
-        }
-
-        .nav-btn {
-            padding: 10px 20px;
-            background-color: var(--accent-1);
-            color: white;
-            border: none;
-            border-radius: 30px;
-            font-weight: bold;
-            cursor: pointer;
-            transition: all 0.3s ease;
-        }
-
-        .nav-btn:hover {
-            background-color: var(--secondary-bg);
-            transform: scale(1.05);
+            font-size: 1.1em;
+            color: var(--text);
         }
     </style>
 </head>
 <body>
-    <header>
-        Python学習メニュー設計 - 型選択工学による1週間カリキュラム
+  <div class="wrap">
+    <header class="page-header">
+        <p class="eyebrow">VEGA COURSE</p>
+        <h1>Python学習メニュー設計 - 型選択工学による1週間カリキュラム</h1>
+        <p class="lede">トップページと同じダークスペーストーンで、1日1時間×1週間の計画を読みやすく整理しました。</p>
     </header>
 
-    <div class="container">
-        <div class="section-1">
+    <main class="flow">
+        <section class="panel flow">
+        <div class="scope-section section-1">
             <h2>論文の枠組みをPython学習に応用</h2>
             <p>以下では、添付論文の枠組み</p>
             <div class="math-container">
@@ -293,7 +50,7 @@
             <p>（世界 \((W)\) と制約 \((E)\) から、観点 \((S)\) と離散条件 \((A(S))\) を設計する）を、<strong>「Python学習メニュー設計」</strong>にそのまま当てはめて、1日1時間×1週間のトレーニング計画を作ります。</p>
         </div>
 
-        <div class="section-2">
+        <div class="scope-section section-2">
             <h2>1. 設計対象を論文の記号で定義する</h2>
             
             <h3>世界 \((W)\)：この1週間で扱う「Pythonプログラミング世界」</h3>
@@ -338,7 +95,7 @@
             </ul>
         </div>
 
-        <div class="section-3">
+        <div class="scope-section section-3">
             <h2>2. 中間生成物①：観点 \((S)\) を設計する（何を区別したいか）</h2>
             <p>論文では観点 \((S)\) を「観測関数 \((o_S: W \to O_S)\)」として扱います。
             ここでは <strong>学習者が書いた小さなプログラム</strong> \((w \in W)\) を観測して、</p>
@@ -366,7 +123,7 @@
             <p>この \((S)\) はまさに「プログラミングとは型を選択する工学」を、観測可能な形に落としたものです。</p>
         </div>
 
-        <div class="section-4">
+        <div class="scope-section section-4">
             <h2>3. 中間生成物②：\((A(S))\) を設計する（離散的な"学習条件"の集合）</h2>
             <p>論文では</p>
             <div class="math-container">
@@ -380,7 +137,8 @@
             <h3>✅ \((A(S))\)：この1週間で押さえる"型選択パターン"の等価クラス（10個）</h3>
             <p>7時間なので、全部は無理です。初心者が「型選択の核」を掴める最小セットとして <strong>10クラス</strong>に絞ります。</p>
             
-            <table>
+            <div class="table-scroll">
+                <table>
                 <thead>
                     <tr>
                         <th>ID</th>
@@ -474,11 +232,12 @@
                     </tr>
                 </tbody>
             </table>
+            </div>
             
             <p>※ <code>record</code> は最初は <code>tuple</code> や <code>dict</code> でよいです。後で <code>dataclass</code> に昇格させます（これが「型を選ぶ」の練習）。</p>
         </div>
 
-        <div class="section-5">
+        <div class="scope-section section-5">
             <h2>4. 1日1時間×1週間メニュー（A(S)を被覆する"代表演習集合"）</h2>
             <p>論文の「テストスイート選択＝被覆問題」の発想に沿って言うと、</p>
             
@@ -708,7 +467,7 @@
             </div>
         </div>
 
-        <div class="section-1">
+        <div class="scope-section section-1">
             <h2>5. まとめ：この設計が論文モデルに沿っている点（短く整理）</h2>
             
             <ul>
@@ -720,7 +479,7 @@
             </ul>
         </div>
 
-        <div class="section-3">
+        <div class="scope-section section-3">
             <h2>追加提案</h2>
             <p>もし、あなたが望むなら次の追加も作れます（質問は不要です、どちらでも続けられます）：</p>
             
@@ -729,11 +488,13 @@
                 <li>A(S) の各クラスに対する <strong>"よくある誤り"＝エラー推測（経験ベース）</strong> の観点追加（論文4.5のノリで）</li>
             </ul>
         </div>
-    </div>
+        </section>
+    </main>
 
     <div class="footer">
-        Python学習メニュー設計 - 型選択工学による1週間カリキュラム © 2023
+        Python学習メニュー設計 - 型選択工学による1週間カリキュラム © 2023 | VEGAコース調整
     </div>
+  </div>
 
     <script>
         // KaTeXの自動レンダリング設定

--- a/bt7/spec.html
+++ b/bt7/spec.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <meta name="theme-color" content="#0b0f14">
   <title>BEAT楽器 — 動く仕様書（Responsive / WebAudio）</title>
+  <link rel="stylesheet" href="vega_theme.css">
 
   <style>
     :root{

--- a/bt7/vega_theme.css
+++ b/bt7/vega_theme.css
@@ -1,0 +1,377 @@
+:root {
+  --bg0: #06070c;
+  --bg1: #0b1024;
+  --bg2: #120b2a;
+  --card: rgba(255, 255, 255, 0.06);
+  --card2: rgba(255, 255, 255, 0.1);
+  --line: rgba(255, 255, 255, 0.16);
+  --text: rgba(255, 255, 255, 0.92);
+  --muted: rgba(255, 255, 255, 0.7);
+  --muted2: rgba(255, 255, 255, 0.55);
+  --accent: #7cf7ff;
+  --accent2: #a78bfa;
+  --hot: #ff5ea8;
+  --gold: #ffd36e;
+  --shadow: 0 16px 60px rgba(0, 0, 0, 0.55);
+  --r: 18px;
+  --max: 1120px;
+  --navH: 64px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", Meiryo, Arial, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 700px at 70% 10%, rgba(167, 139, 250, 0.2), transparent 55%),
+    radial-gradient(900px 560px at 20% 25%, rgba(124, 247, 255, 0.16), transparent 55%),
+    radial-gradient(760px 560px at 80% 60%, rgba(255, 94, 168, 0.1), transparent 60%),
+    linear-gradient(180deg, var(--bg0), var(--bg1) 45%, var(--bg2));
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: -40px;
+  z-index: 1;
+  pointer-events: none;
+  background-image:
+    radial-gradient(circle at 15% 25%, rgba(255, 255, 255, 0.04) 0 1px, transparent 2px),
+    radial-gradient(circle at 65% 55%, rgba(255, 255, 255, 0.035) 0 1px, transparent 2px),
+    radial-gradient(circle at 45% 85%, rgba(255, 255, 255, 0.03) 0 1px, transparent 2px);
+  background-size: 320px 320px, 420px 420px, 520px 520px;
+  opacity: 0.35;
+  mix-blend-mode: screen;
+  transform: translate3d(0, 0, 0);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+a:hover {
+  color: var(--accent2);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid rgba(124, 247, 255, 0.9);
+  outline-offset: 3px;
+  border-radius: 12px;
+}
+
+.wrap {
+  position: relative;
+  z-index: 2;
+  width: min(var(--max), calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.page-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: linear-gradient(180deg, rgba(6, 7, 12, 0.82), rgba(6, 7, 12, 0.35));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 16px 0 10px;
+}
+
+.page-header h1 {
+  margin: 6px 0 0;
+  font-size: clamp(22px, 3.2vw, 34px);
+  letter-spacing: 0.01em;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.lede {
+  margin: 6px 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+  max-width: 860px;
+}
+
+.panel {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.04));
+  border-radius: calc(var(--r) + 4px);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  position: relative;
+  padding: 24px;
+}
+
+.panel::before {
+  content: "";
+  position: absolute;
+  inset: -60px;
+  background:
+    radial-gradient(600px 260px at 30% 20%, rgba(124, 247, 255, 0.18), transparent 60%),
+    radial-gradient(540px 240px at 70% 40%, rgba(167, 139, 250, 0.16), transparent 65%),
+    radial-gradient(520px 240px at 60% 90%, rgba(255, 94, 168, 0.1), transparent 70%);
+  pointer-events: none;
+  opacity: 0.95;
+}
+
+.panel > * {
+  position: relative;
+  z-index: 2;
+}
+
+.flow > * + * {
+  margin-top: 18px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+
+.label-set {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.issue-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  font-weight: 650;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.label-epic { background: linear-gradient(135deg, rgba(255, 94, 168, 0.32), rgba(255, 94, 168, 0.2)); border-color: rgba(255, 94, 168, 0.5); }
+.label-feature { background: linear-gradient(135deg, rgba(124, 247, 255, 0.32), rgba(124, 247, 255, 0.16)); border-color: rgba(124, 247, 255, 0.45); }
+.label-bug { background: linear-gradient(135deg, rgba(255, 94, 94, 0.32), rgba(255, 94, 94, 0.18)); border-color: rgba(255, 94, 94, 0.45); }
+.label-test { background: linear-gradient(135deg, rgba(255, 211, 110, 0.32), rgba(255, 211, 110, 0.18)); border-color: rgba(255, 211, 110, 0.48); color: var(--text); }
+.label-docs { background: linear-gradient(135deg, rgba(167, 139, 250, 0.32), rgba(167, 139, 250, 0.18)); border-color: rgba(167, 139, 250, 0.45); }
+.label-refactor { background: linear-gradient(135deg, rgba(124, 247, 255, 0.28), rgba(167, 139, 250, 0.18)); border-color: rgba(124, 247, 255, 0.45); }
+.label-feature,
+.label-b1,
+.label-b2,
+.label-b3,
+.label-b4,
+.label-b5,
+.label-b6,
+.label-b7,
+.label-b8,
+.label-b9,
+.label-b10 { color: var(--text); }
+
+.label-b1 { background: linear-gradient(135deg, rgba(255, 115, 80, 0.32), rgba(255, 115, 80, 0.18)); border-color: rgba(255, 115, 80, 0.4); }
+.label-b2 { background: linear-gradient(135deg, rgba(255, 170, 80, 0.32), rgba(255, 170, 80, 0.18)); border-color: rgba(255, 170, 80, 0.4); }
+.label-b3 { background: linear-gradient(135deg, rgba(255, 210, 110, 0.32), rgba(255, 210, 110, 0.18)); border-color: rgba(255, 210, 110, 0.4); }
+.label-b4 { background: linear-gradient(135deg, rgba(135, 207, 120, 0.32), rgba(135, 207, 120, 0.18)); border-color: rgba(135, 207, 120, 0.35); }
+.label-b5 { background: linear-gradient(135deg, rgba(100, 195, 120, 0.32), rgba(100, 195, 120, 0.18)); border-color: rgba(100, 195, 120, 0.38); }
+.label-b6 { background: linear-gradient(135deg, rgba(90, 190, 180, 0.32), rgba(90, 190, 180, 0.18)); border-color: rgba(90, 190, 180, 0.4); }
+.label-b7 { background: linear-gradient(135deg, rgba(90, 200, 220, 0.32), rgba(90, 200, 220, 0.18)); border-color: rgba(90, 200, 220, 0.4); }
+.label-b8 { background: linear-gradient(135deg, rgba(110, 160, 255, 0.32), rgba(110, 160, 255, 0.18)); border-color: rgba(110, 160, 255, 0.4); }
+.label-b9 { background: linear-gradient(135deg, rgba(100, 140, 255, 0.32), rgba(100, 140, 255, 0.18)); border-color: rgba(100, 140, 255, 0.4); }
+.label-b10 { background: linear-gradient(135deg, rgba(140, 120, 255, 0.32), rgba(140, 120, 255, 0.18)); border-color: rgba(140, 120, 255, 0.4); }
+.label-good-first { background: linear-gradient(135deg, rgba(255, 94, 168, 0.32), rgba(255, 94, 168, 0.18)); border-color: rgba(255, 94, 168, 0.5); color: var(--text); }
+
+.section-milestone,
+.section-issue {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.32);
+  border-radius: var(--r);
+  padding: 18px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.section-milestone::before,
+.section-issue::before {
+  content: "";
+  position: absolute;
+  inset: -80px;
+  background: radial-gradient(460px 200px at 20% 10%, rgba(124, 247, 255, 0.14), transparent 60%),
+    radial-gradient(420px 200px at 90% 20%, rgba(167, 139, 250, 0.12), transparent 65%);
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+.section-milestone > *,
+.section-issue > * {
+  position: relative;
+  z-index: 2;
+}
+
+.section-issue {
+  border-left: 4px solid rgba(124, 247, 255, 0.6);
+  padding-left: 22px;
+}
+
+.section-milestone {
+  border-left: 4px solid rgba(167, 139, 250, 0.7);
+  padding-left: 22px;
+}
+
+.math-container {
+  background: rgba(0, 0, 0, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--r);
+  padding: 14px;
+  box-shadow: var(--shadow);
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 12px 0;
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  overflow: hidden;
+  color: var(--text);
+}
+
+th,
+td {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 10px;
+}
+
+th {
+  background: linear-gradient(135deg, rgba(124, 247, 255, 0.22), rgba(167, 139, 250, 0.18));
+  color: var(--text);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 750;
+}
+
+tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.32);
+  color: #d6e6f7;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-left: 4px solid rgba(124, 247, 255, 0.4);
+  padding: 12px;
+  border-radius: 14px;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto Sans Mono", "Liberation Mono", monospace;
+  font-size: 13px;
+}
+
+.section-1,
+.section-2,
+.section-3,
+.section-4,
+.section-5 {
+  border-radius: var(--r);
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow);
+}
+
+.section-1 { background: linear-gradient(135deg, rgba(124, 247, 255, 0.12), rgba(124, 247, 255, 0.05)); }
+.section-2 { background: linear-gradient(135deg, rgba(135, 207, 120, 0.12), rgba(135, 207, 120, 0.05)); }
+.section-3 { background: linear-gradient(135deg, rgba(255, 211, 110, 0.16), rgba(255, 211, 110, 0.06)); color: var(--text); }
+.section-4 { background: linear-gradient(135deg, rgba(167, 139, 250, 0.16), rgba(167, 139, 250, 0.08)); }
+.section-5 { background: linear-gradient(135deg, rgba(255, 94, 168, 0.16), rgba(255, 94, 168, 0.08)); }
+
+.footer {
+  text-align: center;
+  padding: 12px;
+  background: linear-gradient(135deg, rgba(124, 247, 255, 0.2), rgba(167, 139, 250, 0.16));
+  color: var(--text);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin-top: 32px;
+  border-radius: var(--r) var(--r) 0 0;
+}
+
+@media (max-width: 768px) {
+  .panel {
+    padding: 18px;
+  }
+
+  .page-header {
+    padding: 14px 0 8px;
+  }
+
+  .page-header h1 {
+    font-size: clamp(20px, 5vw, 28px);
+  }
+}
+
+/* Tables: keep contrast and allow horizontal scroll on small screens */
+.table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 12px 0;
+}
+
+table {
+  min-width: 640px;
+}
+
+th,
+td {
+  color: var(--text);
+}
+
+@media (max-width: 768px) {
+  table {
+    min-width: 520px;
+  }
+
+  th,
+  td {
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
## Summary
- raise text contrast across the VEGA theme and labels to match the dark space palette
- add responsive table wrappers and mobile-friendly min-width tuning for VEGA course pages
- wrap VEGA overview/scope tables in scroll containers to prevent horizontal overflow on small screens

## Testing
- not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa9d1ba1883339de8c0949ee798e4)