### PR TITLE
Align VEGA subpages with top-level design

### DIFF
--- a/bt7/index.html
+++ b/bt7/index.html
@@ -3,19 +3,87 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="dark">
     <title>BEAT楽器トレーニング計画 - VEGAコース</title>
     <link rel="stylesheet" href="vega_theme.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
 </head>
 <body>
-  <div class="wrap">
-    <header class="page-header">
-      <p class="eyebrow">VEGA COURSE</p>
-      <h1>BEAT楽器トレーニング計画</h1>
-      <p class="lede">GitHub Issues Backlog: Python「BEAT楽器」（ミニ・ドラムマシン）— トップページのスペース感に合わせたダークテーマで整理しました。</p>
-    </header>
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
 
-    <main class="flow">
+  <header class="course-header">
+    <div class="wrap">
+      <div class="nav">
+        <div class="brand">
+          <div class="logo" aria-hidden="true"></div>
+          <div>
+            <h1>Python Training</h1>
+            <p>VEGA Course | BEAT楽器</p>
+          </div>
+        </div>
+        <nav aria-label="VEGAコースナビゲーション">
+          <div class="navlinks">
+            <a href="../index.html">トップページ</a>
+            <a href="./index.html">VEGAホーム</a>
+            <a href="./overview.html">概要</a>
+            <a href="./scope.html">スコープ</a>
+            <a href="./spec.html">仕様</a>
+          </div>
+          <div class="cta">
+            <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+            <a class="btn" href="./spec.html"><span class="dot" aria-hidden="true"></span>デモを見る</a>
+          </div>
+          <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+            <span aria-hidden="true"></span>
+          </button>
+        </nav>
+      </div>
+    </div>
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a href="./index.html">VEGAホーム</a>
+        <a href="./overview.html">概要</a>
+        <a href="./scope.html">スコープ</a>
+        <a href="./spec.html">仕様</a>
+        <div class="row">
+          <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn" href="./spec.html"><span class="dot" aria-hidden="true"></span>仕様を試す</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="wrap flow">
+      <section class="panel course-hero">
+        <div class="page-header">
+          <p class="eyebrow">VEGA COURSE</p>
+          <h1>BEAT楽器トレーニング計画</h1>
+          <p class="lede">GitHub Issues Backlog: Python「BEAT楽器」（ミニ・ドラムマシン）— トップページのスペース感に合わせたダークテーマで整理しました。</p>
+        </div>
+        <div class="hero-actions">
+          <a class="btn primary" href="./overview.html"><span class="dot" aria-hidden="true"></span>概要（観点設計）</a>
+          <a class="btn" href="./scope.html"><span class="dot" aria-hidden="true"></span>1週間スコープ</a>
+          <a class="btn" href="./spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書</a>
+        </div>
+        <div class="meta-grid">
+          <div class="meta-card">
+            <strong>成果物</strong>
+            beat.wav / ASCII可視化 / CLIパイプライン
+          </div>
+          <div class="meta-card">
+            <strong>想定ペース</strong>
+            1日1時間 × 7日（初心者OK）
+          </div>
+          <div class="meta-card">
+            <strong>トーン</strong>
+            宇宙を感じるダークテーマとグラデーション
+          </div>
+        </div>
+      </section>
+
       <section class="panel flow">
         <div class="math-container">
           <p><strong>時間解像度の計算式:</strong></p>
@@ -808,6 +876,7 @@ H:x-x-x-x-x-x-x-x-</code></pre>
             <p>イベント時間: \(t_{\text{event}} = n_{\text{step}} \times t_{\text{step}}\)</p>
             <p>サンプル位置: \(s_{\text{pos}} = \lfloor t_{\text{event}} \times f_s \rfloor\)</p>
         </div>
+      </div>
     </main>
     
     <div class="footer">
@@ -830,6 +899,6 @@ H:x-x-x-x-x-x-x-x-</code></pre>
             });
         });
     </script>
-  </div>
+    <script src="vega_shared.js"></script>
 </body>
 </html>

--- a/bt7/overview.html
+++ b/bt7/overview.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="dark">
     <title>BEAT楽器トレーニング計画 - 型を選択する工学</title>
     <link rel="stylesheet" href="vega_theme.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
@@ -27,22 +28,85 @@
             font-size: 1.1em;
             color: var(--text);
         }
-
-        .table-wrap {
-            overflow-x: auto;
-        }
     </style>
 </head>
 <body>
-  <div class="wrap">
-    <header class="page-header">
-        <p class="eyebrow">VEGA COURSE</p>
-        <h1>🎵 BEAT楽器トレーニング計画 🥁</h1>
-        <p class="lede">トップページの宇宙感に合わせたダークトーンに統一し、「プログラミング＝型を選択する工学」の学習導線を整理しました。</p>
-    </header>
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
 
-    <main class="flow">
-        <section class="panel flow">
+  <header class="course-header">
+    <div class="wrap">
+      <div class="nav">
+        <div class="brand">
+          <div class="logo" aria-hidden="true"></div>
+          <div>
+            <h1>Python Training</h1>
+            <p>VEGA Course | Overview</p>
+          </div>
+        </div>
+        <nav aria-label="VEGAコースナビゲーション">
+          <div class="navlinks">
+            <a href="../index.html">トップページ</a>
+            <a href="./index.html">VEGAホーム</a>
+            <a href="./overview.html">概要</a>
+            <a href="./scope.html">スコープ</a>
+            <a href="./spec.html">仕様</a>
+          </div>
+          <div class="cta">
+            <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+            <a class="btn" href="./scope.html"><span class="dot" aria-hidden="true"></span>学習メニュー</a>
+          </div>
+          <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+            <span aria-hidden="true"></span>
+          </button>
+        </nav>
+      </div>
+    </div>
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a href="./index.html">VEGAホーム</a>
+        <a href="./overview.html">概要</a>
+        <a href="./scope.html">スコープ</a>
+        <a href="./spec.html">仕様</a>
+        <div class="row">
+          <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn" href="./spec.html"><span class="dot" aria-hidden="true"></span>デモを見る</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="wrap flow">
+      <section class="panel course-hero">
+        <div class="page-header">
+            <p class="eyebrow">VEGA COURSE</p>
+            <h1>🎵 BEAT楽器トレーニング計画 🥁</h1>
+            <p class="lede">トップページの宇宙感に合わせたダークトーンに統一し、「プログラミング＝型を選択する工学」の学習導線を整理しました。</p>
+        </div>
+        <div class="hero-actions">
+          <a class="btn primary" href="./index.html"><span class="dot" aria-hidden="true"></span>Issue Backlog</a>
+          <a class="btn" href="./scope.html"><span class="dot" aria-hidden="true"></span>1週間メニュー</a>
+          <a class="btn" href="./spec.html"><span class="dot" aria-hidden="true"></span>WebAudio仕様</a>
+        </div>
+        <div class="meta-grid">
+          <div class="meta-card">
+            <strong>骨格</strong>
+            観点 (S) と A(S) で型選択パターンを可視化
+          </div>
+          <div class="meta-card">
+            <strong>ペース</strong>
+            1日1時間 × 7日 / スマホでも読みやすい
+          </div>
+          <div class="meta-card">
+            <strong>カラー</strong>
+            トップページと同一のダーク + ネオンアクセント
+          </div>
+        </div>
+      </section>
+
+      <section class="panel flow">
         <div class="training-section section-1">
             <h2>前回の設計（論文の枠組み）</h2>
             <div class="math-container">
@@ -127,6 +191,7 @@
             <h3>✅ (A(S))：ビート楽器で身につける「型選択パターン」10クラス</h3>
             <p>（= 7時間で"被覆"したい離散条件集合。各クラスに代表演習を1つ置きます）</p>
             
+            <div class="table-wrap">
             <table>
                 <thead>
                     <tr>
@@ -221,6 +286,7 @@
                     </tr>
                 </tbody>
             </table>
+            </div>
             <blockquote>
                 <p>この (A(S)) を、1日1時間×7日でできるだけ少ない演習で"被覆"する（論文の set cover / hitting set の発想）＝今回のメニュー設計です。</p>
             </blockquote>
@@ -373,12 +439,12 @@ H:x-x-x-x-x-x-x-x-</pre>
             </ul>
         </div>
         </section>
+      </div>
     </main>
 
     <div class="footer">
         <p>BEAT楽器トレーニング計画 — VEGAコース | 宇宙感ダークテーマに統一</p>
     </div>
-  </div>
 
     <!-- KaTeX JS -->
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8" crossorigin="anonymous"></script>
@@ -392,5 +458,6 @@ H:x-x-x-x-x-x-x-x-</pre>
             ],
             throwOnError: false
         });"></script>
+    <script src="vega_shared.js"></script>
 </body>
 </html>

--- a/bt7/scope.html
+++ b/bt7/scope.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="dark">
     <title>Python学習メニュー設計 - 型選択工学による1週間カリキュラム</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -32,15 +33,82 @@
     </style>
 </head>
 <body>
-  <div class="wrap">
-    <header class="page-header">
-        <p class="eyebrow">VEGA COURSE</p>
-        <h1>Python学習メニュー設計 - 型選択工学による1週間カリキュラム</h1>
-        <p class="lede">トップページと同じダークスペーストーンで、1日1時間×1週間の計画を読みやすく整理しました。</p>
-    </header>
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
 
-    <main class="flow">
-        <section class="panel flow">
+  <header class="course-header">
+    <div class="wrap">
+      <div class="nav">
+        <div class="brand">
+          <div class="logo" aria-hidden="true"></div>
+          <div>
+            <h1>Python Training</h1>
+            <p>VEGA Course | Scope</p>
+          </div>
+        </div>
+        <nav aria-label="VEGAコースナビゲーション">
+          <div class="navlinks">
+            <a href="../index.html">トップページ</a>
+            <a href="./index.html">VEGAホーム</a>
+            <a href="./overview.html">概要</a>
+            <a href="./scope.html">スコープ</a>
+            <a href="./spec.html">仕様</a>
+          </div>
+          <div class="cta">
+            <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+            <a class="btn" href="./index.html"><span class="dot" aria-hidden="true"></span>Issue Backlog</a>
+          </div>
+          <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+            <span aria-hidden="true"></span>
+          </button>
+        </nav>
+      </div>
+    </div>
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a href="./index.html">VEGAホーム</a>
+        <a href="./overview.html">概要</a>
+        <a href="./scope.html">スコープ</a>
+        <a href="./spec.html">仕様</a>
+        <div class="row">
+          <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn" href="./spec.html"><span class="dot" aria-hidden="true"></span>デモを見る</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="wrap flow">
+      <section class="panel course-hero">
+        <div class="page-header">
+            <p class="eyebrow">VEGA COURSE</p>
+            <h1>Python学習メニュー設計 - 型選択工学による1週間カリキュラム</h1>
+            <p class="lede">トップページと同じダークスペーストーンで、1日1時間×1週間の計画を読みやすく整理しました。</p>
+        </div>
+        <div class="hero-actions">
+          <a class="btn primary" href="./overview.html"><span class="dot" aria-hidden="true"></span>概要へ</a>
+          <a class="btn" href="./index.html"><span class="dot" aria-hidden="true"></span>Issue Backlog</a>
+          <a class="btn" href="./spec.html"><span class="dot" aria-hidden="true"></span>仕様を見る</a>
+        </div>
+        <div class="meta-grid">
+          <div class="meta-card">
+            <strong>スコープ</strong>
+            1日1時間 × 7日で A(S) を被覆する演習セット
+          </div>
+          <div class="meta-card">
+            <strong>視認性</strong>
+            背景と文字色をトップページと同一トーンに調整
+          </div>
+          <div class="meta-card">
+            <strong>モバイル</strong>
+            テーブルも横スクロールで崩れないレスポンシブ
+          </div>
+        </div>
+      </section>
+
+      <section class="panel flow">
         <div class="scope-section section-1">
             <h2>論文の枠組みをPython学習に応用</h2>
             <p>以下では、添付論文の枠組み</p>
@@ -137,6 +205,7 @@
             <h3>✅ \((A(S))\)：この1週間で押さえる"型選択パターン"の等価クラス（10個）</h3>
             <p>7時間なので、全部は無理です。初心者が「型選択の核」を掴める最小セットとして <strong>10クラス</strong>に絞ります。</p>
             
+            <div class="table-wrap">
             <table>
                 <thead>
                     <tr>
@@ -231,6 +300,7 @@
                     </tr>
                 </tbody>
             </table>
+            </div>
             
             <p>※ <code>record</code> は最初は <code>tuple</code> や <code>dict</code> でよいです。後で <code>dataclass</code> に昇格させます（これが「型を選ぶ」の練習）。</p>
         </div>
@@ -487,12 +557,12 @@
             </ul>
         </div>
         </section>
+      </div>
     </main>
 
     <div class="footer">
         Python学習メニュー設計 - 型選択工学による1週間カリキュラム © 2023 | VEGAコース調整
     </div>
-  </div>
 
     <script>
         // KaTeXの自動レンダリング設定
@@ -508,5 +578,6 @@
             });
         });
     </script>
+    <script src="vega_shared.js"></script>
 </body>
 </html>

--- a/bt7/spec.html
+++ b/bt7/spec.html
@@ -4,188 +4,196 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <meta name="theme-color" content="#0b0f14">
+  <meta name="color-scheme" content="dark">
   <title>BEAT楽器 — 動く仕様書（Responsive / WebAudio）</title>
   <link rel="stylesheet" href="vega_theme.css">
 
   <style>
-    :root{
-      --bg:#0b0f14; --panel:#121a24; --panel2:#0f1620;
-      --txt:#e6edf3; --muted:#9fb0c0; --accent:#7ee787; --warn:#ff7b72;
-      --line:#223042;
-      --radius:16px;
-      --shadow: 0 10px 30px rgba(0,0,0,.35);
-      --stepSize: 34px;
-    }
-    *{ box-sizing:border-box; }
-    html,body{ height:100%; }
-    body{
-      margin:0;
-      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Hiragino Kaku Gothic ProN", "Noto Sans JP", Arial, "Apple Color Emoji","Segoe UI Emoji";
-      background: radial-gradient(1200px 700px at 20% 0%, #112033 0%, var(--bg) 55%);
-      color: var(--txt);
-    }
-    a{ color: var(--accent); }
-    .wrap{
-      max-width: 1100px;
-      margin: 0 auto;
-      padding: 16px 14px 44px;
-    }
-    header{
-      display:flex; align-items:flex-start; justify-content:space-between; gap:14px;
-      margin: 10px 0 14px;
-    }
-    .title{ display:flex; flex-direction:column; gap:6px; }
-    h1{ margin:0; font-size: 20px; letter-spacing:.3px; }
-    .subtitle{ color: var(--muted); font-size: 13px; line-height: 1.4; }
+    :root { --stepSize: 34px; }
 
-    .badge{
-      background: linear-gradient(180deg, rgba(126,231,135,.18), rgba(126,231,135,.08));
-      border: 1px solid rgba(126,231,135,.25);
+    .spec-grid {
+      display: grid;
+      grid-template-columns: 1.1fr 0.9fr;
+      gap: 14px;
+      align-items: flex-start;
+    }
+
+    .card {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.04));
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 20px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .card .hd {
+      padding: 12px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .card .hd h2 {
+      margin: 0;
+      font-size: 14px;
+      letter-spacing: 0.2px;
+    }
+
+    .card .bd { padding: 14px; }
+
+    .muted { color: var(--muted); }
+
+    .mono {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto Sans Mono", "Liberation Mono", monospace;
+    }
+
+    .badge {
+      background: linear-gradient(135deg, rgba(124, 247, 255, 0.16), rgba(167, 139, 250, 0.12));
+      border: 1px solid rgba(124, 247, 255, 0.35);
       padding: 10px 12px;
       border-radius: 14px;
       box-shadow: var(--shadow);
       min-width: 260px;
     }
-    .badge .row{ display:flex; justify-content:space-between; gap:10px; }
-    .badge .k{ color:var(--muted); font-size:12px; }
-    .badge .v{ font-weight:600; font-size:12px; }
 
-    main{
-      display:grid;
-      grid-template-columns: 1.2fr .8fr;
-      gap: 14px;
-    }
-    .card{
-      background: linear-gradient(180deg, rgba(18,26,36,.92), rgba(15,22,32,.92));
-      border: 1px solid rgba(255,255,255,.06);
-      border-radius: var(--radius);
-      box-shadow: var(--shadow);
-      overflow:hidden;
-    }
-    .card .hd{
-      padding: 12px 12px 10px;
-      border-bottom: 1px solid rgba(255,255,255,.06);
-      display:flex; align-items:center; justify-content:space-between; gap:12px;
-      flex-wrap: wrap;
-    }
-    .card .hd h2{
-      margin:0;
-      font-size:14px;
-      letter-spacing:.2px;
-    }
-    .card .bd{ padding: 12px; }
-    .muted{ color: var(--muted); }
-    .mono{ font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto Sans Mono", "Liberation Mono", monospace; }
+    .badge .row { display: flex; justify-content: space-between; gap: 10px; }
+    .badge .k { color: var(--muted); font-size: 12px; }
+    .badge .v { font-weight: 650; font-size: 12px; color: var(--text); }
 
-    .controls{
-      display:grid;
+    .controls {
+      display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 10px;
     }
-    .ctrl{
-      background: rgba(0,0,0,.18);
-      border: 1px solid rgba(255,255,255,.06);
+
+    .ctrl {
+      background: rgba(0, 0, 0, 0.22);
+      border: 1px solid rgba(255, 255, 255, 0.12);
       border-radius: 14px;
       padding: 10px;
     }
-    .ctrl label{
-      display:flex; justify-content:space-between; gap:10px;
-      font-size: 12px; color: var(--muted);
-      margin-bottom: 8px;
-    }
-    input[type="range"]{ width:100%; }
 
-    .btns{
-      display:flex; gap:10px; flex-wrap:wrap;
-      align-items:center;
-    }
-    button{
-      border:1px solid rgba(255,255,255,.1);
-      background: rgba(255,255,255,.06);
-      color: var(--txt);
-      padding: 10px 12px;
-      border-radius: 14px;
-      cursor:pointer;
-      font-weight:600;
-      letter-spacing:.2px;
-      touch-action: manipulation;
-      user-select:none;
-      -webkit-tap-highlight-color: transparent;
-    }
-    button.primary{
-      background: linear-gradient(180deg, rgba(126,231,135,.25), rgba(126,231,135,.12));
-      border-color: rgba(126,231,135,.3);
-    }
-    button.danger{
-      background: linear-gradient(180deg, rgba(255,123,114,.22), rgba(255,123,114,.10));
-      border-color: rgba(255,123,114,.25);
-    }
-    button:disabled{ opacity:.55; cursor:not-allowed; }
-
-    .gridWrap{ display:flex; flex-direction:column; gap:10px; }
-    .trackRow{
-      display:grid;
-      grid-template-columns: 70px 1fr;
+    .ctrl label {
+      display: flex;
+      justify-content: space-between;
       gap: 10px;
-      align-items:center;
-    }
-    .trackLabel{
       font-size: 12px;
       color: var(--muted);
-      display:flex; flex-direction:column; gap:2px;
+      margin-bottom: 8px;
     }
-    .trackLabel strong{ color: var(--txt); font-size: 13px; }
 
-    .steps{
-      display:grid;
+    input[type="range"] { width: 100%; accent-color: var(--accent); }
+
+    .btns {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    button {
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--text);
+      padding: 10px 12px;
+      border-radius: 14px;
+      cursor: pointer;
+      font-weight: 600;
+      letter-spacing: 0.2px;
+      touch-action: manipulation;
+      user-select: none;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    button.primary {
+      background: linear-gradient(135deg, rgba(124, 247, 255, 0.22), rgba(167, 139, 250, 0.16));
+      border-color: rgba(124, 247, 255, 0.35);
+    }
+
+    button.danger {
+      background: linear-gradient(135deg, rgba(255, 94, 94, 0.25), rgba(255, 94, 168, 0.14));
+      border-color: rgba(255, 94, 94, 0.38);
+    }
+
+    button:disabled { opacity: 0.55; cursor: not-allowed; }
+
+    .gridWrap { display: flex; flex-direction: column; gap: 10px; }
+
+    .trackRow {
+      display: grid;
+      grid-template-columns: 90px 1fr;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .trackLabel {
+      font-size: 12px;
+      color: var(--muted);
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .trackLabel strong { color: var(--text); font-size: 13px; }
+
+    .steps {
+      display: grid;
       grid-template-columns: repeat(16, var(--stepSize));
       gap: 6px;
-      align-items:center;
-      justify-content:flex-start;
-      overflow-x:auto;
+      align-items: center;
+      justify-content: flex-start;
+      overflow-x: auto;
       padding-bottom: 4px;
       -webkit-overflow-scrolling: touch;
     }
-    .step{
+
+    .step {
       width: var(--stepSize);
       height: var(--stepSize);
       border-radius: 12px;
-      border: 1px solid rgba(255,255,255,.10);
-      background: rgba(0,0,0,.18);
-      display:flex;
-      align-items:center;
-      justify-content:center;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(0, 0, 0, 0.24);
+      display: flex;
+      align-items: center;
+      justify-content: center;
       font-size: 12px;
-      user-select:none;
-      cursor:pointer;
-      position:relative;
+      user-select: none;
+      cursor: pointer;
+      position: relative;
       touch-action: manipulation;
-    }
-    .step.on{
-      background: linear-gradient(180deg, rgba(126,231,135,.35), rgba(126,231,135,.15));
-      border-color: rgba(126,231,135,.35);
-    }
-    .step.playhead::after{
-      content:"";
-      position:absolute;
-      inset:-2px;
-      border-radius: 14px;
-      border: 2px solid rgba(126,231,135,.55);
-      pointer-events:none;
-      box-shadow: 0 0 0 4px rgba(126,231,135,.08);
+      color: var(--text);
     }
 
-    .spec{
-      display:flex;
-      flex-direction:column;
+    .step.on {
+      background: linear-gradient(135deg, rgba(124, 247, 255, 0.28), rgba(167, 139, 250, 0.18));
+      border-color: rgba(124, 247, 255, 0.45);
+    }
+
+    .step.playhead::after {
+      content: "";
+      position: absolute;
+      inset: -2px;
+      border-radius: 14px;
+      border: 2px solid rgba(255, 255, 255, 0.6);
+      pointer-events: none;
+      box-shadow: 0 0 0 4px rgba(124, 247, 255, 0.15);
+    }
+
+    .spec {
+      display: flex;
+      flex-direction: column;
       gap: 10px;
       font-size: 13px;
       line-height: 1.55;
     }
-    .chip{
-      display:inline-flex;
-      background: rgba(0,0,0,.18);
-      border: 1px solid rgba(255,255,255,.06);
+
+    .chip {
+      display: inline-flex;
+      background: rgba(0, 0, 0, 0.24);
+      border: 1px solid rgba(255, 255, 255, 0.12);
       padding: 6px 10px;
       border-radius: 999px;
       color: var(--muted);
@@ -193,70 +201,134 @@
       margin-right: 6px;
       margin-bottom: 6px;
     }
-    pre{
-      margin:0;
+
+    pre {
+      margin: 0;
       padding: 10px;
-      background: rgba(0,0,0,.22);
-      border: 1px solid rgba(255,255,255,.06);
+      background: rgba(0, 0, 0, 0.22);
+      border: 1px solid rgba(255, 255, 255, 0.12);
       border-radius: 14px;
-      overflow:auto;
+      overflow: auto;
       font-size: 12px;
       color: #dbe7f2;
     }
 
-    .status{
-      display:flex; gap:10px; flex-wrap:wrap;
-      align-items:center;
+    .status {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
       padding: 10px;
-      background: rgba(0,0,0,.18);
-      border: 1px solid rgba(255,255,255,.06);
+      background: rgba(0, 0, 0, 0.22);
+      border: 1px solid rgba(255, 255, 255, 0.12);
       border-radius: 14px;
     }
-    .dot{
-      width:10px;height:10px;border-radius:50%;
-      background: rgba(255,255,255,.25);
-    }
-    .dot.ok{ background: rgba(126,231,135,.85); }
-    .dot.bad{ background: rgba(255,123,114,.85); }
 
-    /* responsive */
-    @media (max-width: 900px){
-      main{ grid-template-columns: 1fr; }
-      header{ flex-direction:column; }
-      .badge{ width:100%; min-width: unset; }
-      .trackRow{ grid-template-columns: 60px 1fr; }
-      :root{ --stepSize: 38px; }
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.35);
     }
-    @media (max-width: 520px){
-      /* スマホは操作を大きく */
-      :root{ --stepSize: 40px; }
-      .controls{ grid-template-columns: 1fr; }
-      .btns{ width:100%; }
-      button{ width:100%; padding: 12px 14px; }
-      .card .hd{ align-items:stretch; }
+
+    .dot.ok { background: rgba(124, 247, 255, 0.85); }
+    .dot.bad { background: rgba(255, 94, 94, 0.85); }
+
+    canvas { max-width: 100%; }
+
+    @media (max-width: 960px) {
+      .spec-grid { grid-template-columns: 1fr; }
+      .trackRow { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 540px) {
+      :root { --stepSize: 40px; }
+      .controls { grid-template-columns: 1fr; }
+      .btns { width: 100%; }
+      button { width: 100%; padding: 12px 14px; }
+      .card .hd { align-items: stretch; }
     }
   </style>
 </head>
 
 <body>
-  <div class="wrap">
-    <header>
-      <div class="title">
-        <h1>BEAT楽器 — 動く仕様書</h1>
-        <div class="subtitle">
-          スマホ対応（レスポンシブ）／Web Audio API。<br/>
-          追加：<span class="mono">ブラウザ音声 ON/OFF</span>（WebAudioの生成/停止）を搭載。
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap">
+      <div class="nav">
+        <div class="brand">
+          <div class="logo" aria-hidden="true"></div>
+          <div>
+            <h1>Python Training</h1>
+            <p>VEGA Course | WebAudio Spec</p>
+          </div>
+        </div>
+        <nav aria-label="VEGAコースナビゲーション">
+          <div class="navlinks">
+            <a href="../index.html">トップページ</a>
+            <a href="./index.html">VEGAホーム</a>
+            <a href="./overview.html">概要</a>
+            <a href="./scope.html">スコープ</a>
+            <a href="./spec.html">仕様</a>
+          </div>
+          <div class="cta">
+            <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+            <a class="btn" href="./index.html"><span class="dot" aria-hidden="true"></span>Issue Backlog</a>
+          </div>
+          <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+            <span aria-hidden="true"></span>
+          </button>
+        </nav>
+      </div>
+    </div>
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a href="./index.html">VEGAホーム</a>
+        <a href="./overview.html">概要</a>
+        <a href="./scope.html">スコープ</a>
+        <a href="./spec.html">仕様</a>
+        <div class="row">
+          <a class="btn primary" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn" href="./scope.html"><span class="dot" aria-hidden="true"></span>1週間メニュー</a>
         </div>
       </div>
+    </div>
+  </header>
 
-      <div class="badge" aria-label="runtime status">
-        <div class="row"><div class="k">Audio</div><div class="v mono" id="audioState">off</div></div>
-        <div class="row"><div class="k">BPM</div><div class="v mono" id="bpmView">120</div></div>
-        <div class="row"><div class="k">Step</div><div class="v mono" id="stepView">-</div></div>
-      </div>
-    </header>
+  <main id="main">
+    <div class="wrap flow">
+      <section class="panel course-hero">
+        <div class="page-header">
+          <p class="eyebrow">VEGA COURSE</p>
+          <h1>BEAT楽器 — 動く仕様書</h1>
+          <p class="lede">Web Audio API でブラウザ上にビートマシンを実装し、トップページの宇宙感に合わせたダークテーマへ統一しました。</p>
+        </div>
+        <div class="hero-actions">
+          <a class="btn primary" href="./index.html"><span class="dot" aria-hidden="true"></span>Issue Backlog</a>
+          <a class="btn" href="./overview.html"><span class="dot" aria-hidden="true"></span>観点設計</a>
+          <a class="btn" href="./scope.html"><span class="dot" aria-hidden="true"></span>1週間スコープ</a>
+        </div>
+        <div class="meta-grid">
+          <div class="meta-card">
+            <strong>Audio</strong>
+            <span class="mono" id="audioState">off</span>
+          </div>
+          <div class="meta-card">
+            <strong>BPM</strong>
+            <span class="mono" id="bpmView">120</span>
+          </div>
+          <div class="meta-card">
+            <strong>Step</strong>
+            <span class="mono" id="stepView">-</span>
+          </div>
+        </div>
+      </section>
 
-    <main>
+      <section class="panel">
+        <div class="spec-grid">
       <!-- left -->
       <section class="card">
         <div class="hd">
@@ -360,9 +432,16 @@ H: ----------------</pre>
           </div>
         </div>
       </aside>
-    </main>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <div class="footer">
+    BEAT楽器 — WebAudio仕様 | トップページと調和したダークテーマ
   </div>
 
+  <script src="vega_shared.js"></script>
   <script>
     // -----------------------------
     // Model

--- a/bt7/vega_shared.js
+++ b/bt7/vega_shared.js
@@ -1,0 +1,65 @@
+(() => {
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const hamburger = document.getElementById('hamburger');
+  const mobile = document.getElementById('mobile');
+
+  const toggleMobile = (forceOpen) => {
+    if (!hamburger || !mobile) return;
+    const shouldOpen = typeof forceOpen === 'boolean' ? forceOpen : !mobile.classList.contains('is-open');
+    mobile.classList.toggle('is-open', shouldOpen);
+    hamburger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+  };
+
+  hamburger?.addEventListener('click', (event) => {
+    event.stopPropagation();
+    toggleMobile();
+  });
+
+  mobile?.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => toggleMobile(false));
+  });
+
+  mobile?.addEventListener('click', (event) => {
+    if (event.target === mobile) {
+      toggleMobile(false);
+    }
+  });
+
+  document.addEventListener('keyup', (event) => {
+    if (event.key === 'Escape') toggleMobile(false);
+  });
+
+  const canvas = document.getElementById('starfield');
+  if (canvas && !prefersReducedMotion) {
+    const ctx = canvas.getContext('2d');
+    let width = 0;
+    let height = 0;
+    const density = 140;
+    const stars = Array.from({ length: density }, () => ({ x: Math.random(), y: Math.random(), z: Math.random() * 0.6 + 0.4, tw: Math.random() * 0.4 + 0.6 }));
+
+    const resize = () => {
+      width = canvas.width = window.innerWidth * window.devicePixelRatio;
+      height = canvas.height = window.innerHeight * window.devicePixelRatio;
+      canvas.style.width = '100%';
+      canvas.style.height = '100%';
+    };
+
+    const draw = () => {
+      ctx.clearRect(0, 0, width, height);
+      stars.forEach((s) => {
+        const size = (1.1 - s.z) * 2.2;
+        const opacity = s.tw * 0.9;
+        ctx.fillStyle = `rgba(124,247,255,${opacity})`;
+        ctx.beginPath();
+        ctx.arc(s.x * width, s.y * height, size, 0, Math.PI * 2);
+        ctx.fill();
+      });
+      requestAnimationFrame(draw);
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+    requestAnimationFrame(draw);
+  }
+})();

--- a/bt7/vega_theme.css
+++ b/bt7/vega_theme.css
@@ -55,6 +55,17 @@ body::before {
   transform: translate3d(0, 0, 0);
 }
 
+#starfield {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0.85;
+  filter: drop-shadow(0 0 10px rgba(124, 247, 255, 0.1));
+}
+
 a {
   color: var(--accent);
   text-decoration: none;
@@ -72,6 +83,21 @@ button:focus-visible {
   border-radius: 12px;
 }
 
+.skip {
+  position: absolute;
+  left: -999px;
+  top: 14px;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.82);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  z-index: 9999;
+}
+
+.skip:focus {
+  left: 16px;
+}
+
 .wrap {
   position: relative;
   z-index: 2;
@@ -79,14 +105,227 @@ button:focus-visible {
   margin: 0 auto;
 }
 
-.page-header {
+.course-header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 50;
   backdrop-filter: blur(12px);
-  background: linear-gradient(180deg, rgba(6, 7, 12, 0.82), rgba(6, 7, 12, 0.35));
+  background: linear-gradient(180deg, rgba(6, 7, 12, 0.78), rgba(6, 7, 12, 0.32));
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 16px 0 10px;
+}
+
+.nav {
+  height: var(--navH);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 220px;
+}
+
+.logo {
+  width: 38px;
+  height: 38px;
+  border-radius: 14px;
+  background: radial-gradient(circle at 30% 20%, rgba(124, 247, 255, 0.9), rgba(167, 139, 250, 0.6) 40%, rgba(255, 94, 168, 0.35) 70%, rgba(0, 0, 0, 0) 100%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  position: relative;
+  overflow: hidden;
+}
+
+.logo::after {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background: conic-gradient(from 180deg, rgba(124, 247, 255, 0), rgba(124, 247, 255, 0.25), rgba(255, 94, 168, 0.18), rgba(124, 247, 255, 0));
+  animation: spin 7s linear infinite;
+  opacity: 0.9;
+}
+
+.brand h1 {
+  font-size: 14px;
+  margin: 0;
+  letter-spacing: 0.06em;
+  line-height: 1.1;
+}
+
+.brand p {
+  margin: 2px 0 0 0;
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+}
+
+nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.navlinks {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.navlinks a {
+  padding: 10px 12px;
+  border-radius: 999px;
+  color: var(--muted);
+  border: 1px solid transparent;
+  transition: 0.2s ease;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.navlinks a:hover {
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.btn {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.btn .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px rgba(124, 247, 255, 0.7);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, rgba(124, 247, 255, 0.24), rgba(167, 139, 250, 0.18));
+  border-color: rgba(124, 247, 255, 0.4);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.48);
+}
+
+.hamburger {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+}
+
+.hamburger span,
+.hamburger span::before,
+.hamburger span::after {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: var(--text);
+  border-radius: 999px;
+  position: relative;
+}
+
+.hamburger span::before,
+.hamburger span::after {
+  content: "";
+  position: absolute;
+  left: 0;
+}
+
+.hamburger span::before { top: -8px; }
+.hamburger span::after { top: 8px; }
+
+.mobile {
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 7, 12, 0.82);
+  backdrop-filter: blur(12px);
+  display: none;
+  z-index: 40;
+}
+
+.mobilePanel {
+  width: min(480px, calc(100% - 32px));
+  margin: 90px auto 0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(12, 12, 24, 0.85);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 12px;
+}
+
+.mobilePanel a {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+}
+
+.mobilePanel .row {
+  display: grid;
+  gap: 10px;
+}
+
+.course-hero {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.course-hero::after {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  background:
+    radial-gradient(520px 320px at 12% 10%, rgba(124, 247, 255, 0.25), transparent 60%),
+    radial-gradient(620px 360px at 80% 20%, rgba(167, 139, 250, 0.22), transparent 60%),
+    radial-gradient(520px 320px at 90% 80%, rgba(255, 94, 168, 0.18), transparent 70%);
+  z-index: 1;
+  opacity: 0.7;
+}
+
+.course-hero > * {
+  position: relative;
+  z-index: 2;
+}
+
+.page-header {
+  margin-bottom: 12px;
 }
 
 .page-header h1 {
@@ -108,6 +347,35 @@ button:focus-visible {
   color: var(--muted);
   line-height: 1.6;
   max-width: 860px;
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.meta-card {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.28);
+  padding: 12px;
+  border-radius: 14px;
+  color: var(--muted);
+}
+
+.meta-card strong {
+  display: block;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: 0.01em;
 }
 
 .panel {
@@ -206,7 +474,7 @@ button:focus-visible {
 .label-b7,
 .label-b8,
 .label-b9,
-.label-b10 { color: #041216; }
+.label-b10 { color: var(--text); }
 
 .label-b1 { background: linear-gradient(135deg, rgba(255, 115, 80, 0.32), rgba(255, 115, 80, 0.18)); border-color: rgba(255, 115, 80, 0.4); }
 .label-b2 { background: linear-gradient(135deg, rgba(255, 170, 80, 0.32), rgba(255, 170, 80, 0.18)); border-color: rgba(255, 170, 80, 0.4); }
@@ -285,7 +553,7 @@ td {
 
 th {
   background: linear-gradient(135deg, rgba(124, 247, 255, 0.22), rgba(167, 139, 250, 0.18));
-  color: #041216;
+  color: var(--text);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-weight: 750;
@@ -320,7 +588,7 @@ pre {
 
 .section-1 { background: linear-gradient(135deg, rgba(124, 247, 255, 0.12), rgba(124, 247, 255, 0.05)); }
 .section-2 { background: linear-gradient(135deg, rgba(135, 207, 120, 0.12), rgba(135, 207, 120, 0.05)); }
-.section-3 { background: linear-gradient(135deg, rgba(255, 211, 110, 0.16), rgba(255, 211, 110, 0.06)); color: #1c1200; }
+.section-3 { background: linear-gradient(135deg, rgba(255, 211, 110, 0.16), rgba(255, 211, 110, 0.06)); color: var(--text); }
 .section-4 { background: linear-gradient(135deg, rgba(167, 139, 250, 0.16), rgba(167, 139, 250, 0.08)); }
 .section-5 { background: linear-gradient(135deg, rgba(255, 94, 168, 0.16), rgba(255, 94, 168, 0.08)); }
 
@@ -334,16 +602,42 @@ pre {
   border-radius: var(--r) var(--r) 0 0;
 }
 
+.table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: 14px;
+}
+
+@media (max-width: 900px) {
+  .navlinks {
+    display: none;
+  }
+
+  .hamburger {
+    display: inline-flex;
+  }
+
+  .cta {
+    display: none;
+  }
+
+  .mobile.is-open {
+    display: block;
+  }
+}
+
 @media (max-width: 768px) {
   .panel {
     padding: 18px;
   }
 
-  .page-header {
-    padding: 14px 0 8px;
-  }
-
   .page-header h1 {
     font-size: clamp(20px, 5vw, 28px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .logo::after {
+    animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- Add shared navigation, hero, and starfield elements across VEGA course pages to mirror the top page feel
- Update the VEGA theme for better dark-mode contrast and responsive tables, removing black text on dark backgrounds
- Restyle the interactive WebAudio spec page with the unified layout and status cards

## Testing
- Not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb05c64648333bf5ec968a8a8ad69)