### PR TITLE
Add SIRIUS course and unify tarot pages with main styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,6 +970,7 @@
                 <a class="btn primary" href="#courses"><span class="dot" aria-hidden="true"></span>コース一覧へ</a>
                 <a class="btn" href="#rigel"><span class="dot" aria-hidden="true"></span>NEW: RIGEL</a>
                 <a class="btn" href="#spica"><span class="dot" aria-hidden="true"></span>NEW: SPICA</a>
+                <a class="btn" href="#sirius"><span class="dot" aria-hidden="true"></span>NEW: SIRIUS</a>
                 <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>進め方（GitHub/PR）</a>
                 <a class="btn" href="#faq"><span class="dot" aria-hidden="true"></span>よくある質問</a>
               </div>
@@ -980,6 +981,7 @@
                 <span class="pill"><span class="spark" aria-hidden="true"></span>DENEB: <b>1日30分 / 7日</b></span>
                 <span class="pill"><span class="spark" aria-hidden="true"></span>RIGEL: <b>1日1時間 / 10日</b></span>
                 <span class="pill"><span class="spark" aria-hidden="true"></span>SPICA: <b>1日1時間 / 14日</b></span>
+                <span class="pill"><span class="spark" aria-hidden="true"></span>SIRIUS: <b>1日1時間 / 14日</b></span>
               </div>
             </div>
           </div>
@@ -1270,6 +1272,87 @@
               <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>提出フローを見る</a>
               <a class="btn" href="ec/spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書を開く</a>
               <a class="btn primary" href="ec/index.html"><span class="dot" aria-hidden="true"></span>RIGELを開始</a>
+            </div>
+          </article>
+
+          <!-- SIRIUS -->
+          <article class="course" id="sirius" aria-label="コース SIRIUS">
+            <div class="courseHead">
+              <div class="courseName">
+                <span class="tag hot"><span class="chip" aria-hidden="true"></span>NEW コース SIRIUS</span>
+                <h4>SIRIUS</h4>
+                <p>
+                  タロット占いを題材に、CLI / REST API / Web UI / 自動テストまで作るフルスタックコース。
+                  spread / seed再現 / 正逆位置の仕様を「動く仕様書」で即確認しながら進めます。
+                </p>
+              </div>
+
+              <div class="courseMeta">
+                <div><b>学習目安</b></div>
+                <div>1日1時間 / 14日</div>
+              </div>
+            </div>
+
+            <div class="links" role="list">
+              <a class="linkCard" role="listitem" href="tu/overview.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M12 6v12M6 12h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M4 8c3-4 13-4 16 0M4 16c3 4 13 4 16 0" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>概要・アーキテクチャ</b>
+                  <small>tu/overview.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="tu/implement_spec.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M7 7h10M7 12h10M7 17h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M4 6a2 2 0 0 1 2-2h12v16a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6Z" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>実装仕様書</b>
+                  <small>tu/implement_spec.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="tu/issues.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M7 6h10M7 10h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M6 4a2 2 0 0 1 2-2h8l4 4v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" stroke="currentColor" stroke-width="2"/>
+                    <path d="M15 18h4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>GitHub Issue集</b>
+                  <small>tu/issues.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="tu/spec.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M8 12h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M12 8v8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>動く仕様書</b>
+                  <small>tu/spec.html</small>
+                </div>
+              </a>
+            </div>
+
+            <div class="courseFoot">
+              <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>提出フローを見る</a>
+              <a class="btn" href="tu/spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書を開く</a>
+              <a class="btn primary" href="tu/overview.html"><span class="dot" aria-hidden="true"></span>SIRIUSを開始</a>
             </div>
           </article>
 

--- a/tu/implement_spec.html
+++ b/tu/implement_spec.html
@@ -3,70 +3,59 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>実装仕様書</title>
-  <style>
-:root{
-  --bg:#0b1020;
-  --panel:#111a33;
-  --text:#eef2ff;
-  --muted:#b8c0ff;
-  --accent:#7c5cff;
-  --accent2:#35d0ba;
-  --warn:#ffcc66;
-  --bad:#ff6b6b;
-  --good:#63f2a1;
-  --code:#0a0f1f;
-  --border:rgba(255,255,255,.12);
-  --shadow: 0 8px 24px rgba(0,0,0,.35);
-}
-*{box-sizing:border-box}
-html,body{margin:0;padding:0;background:linear-gradient(180deg, var(--bg), #050714);color:var(--text);font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;line-height:1.6}
-a{color:var(--accent2);text-decoration:none}
-a:hover{text-decoration:underline}
-.container{max-width:1100px;margin:0 auto;padding:24px}
-.header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin:12px 0 18px}
-.brand h1{font-size:22px;margin:0}
-.brand p{margin:6px 0 0;color:var(--muted);font-size:13px}
-.nav{display:flex;flex-wrap:wrap;gap:10px;justify-content:flex-end}
-.nav a{display:inline-block;padding:8px 12px;border:1px solid var(--border);border-radius:999px;background:rgba(255,255,255,.03)}
-.nav a.active{border-color:rgba(124,92,255,.8);box-shadow: 0 0 0 3px rgba(124,92,255,.15) inset}
-.card{background:rgba(255,255,255,.04);border:1px solid var(--border);border-radius:14px;padding:18px;box-shadow:var(--shadow);margin:14px 0}
-.card h2{margin:0 0 10px;font-size:18px}
-.card h3{margin:16px 0 8px;font-size:15px}
-.badge{display:inline-block;padding:2px 10px;border-radius:999px;border:1px solid var(--border);background:rgba(255,255,255,.03);color:var(--muted);font-size:12px}
-.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:14px}
-.col-6{grid-column:span 6}
-.col-4{grid-column:span 4}
-.col-8{grid-column:span 8}
-.col-12{grid-column:span 12}
-@media (max-width: 920px){
-  .col-6,.col-4,.col-8{grid-column:span 12}
-  .header{flex-direction:column;align-items:stretch}
-  .nav{justify-content:flex-start}
-}
-hr{border:0;border-top:1px solid var(--border);margin:16px 0}
-ul{margin:8px 0 8px 22px}
-li{margin:4px 0}
-table{width:100%;border-collapse:collapse;border:1px solid var(--border);border-radius:12px;overflow:hidden}
-th,td{padding:10px 10px;border-bottom:1px solid var(--border);vertical-align:top}
-th{background:rgba(255,255,255,.05);text-align:left;font-weight:600}
-tr:last-child td{border-bottom:0}
-pre{background:var(--code);border:1px solid var(--border);padding:12px;border-radius:12px;overflow:auto}
-code{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto Sans Mono", monospace;font-size: 12.5px}
-.callout{border-left:4px solid var(--accent);padding:12px 14px;background:rgba(124,92,255,.08);border-radius:12px}
-.callout.warn{border-left-color: var(--warn);background:rgba(255,204,102,.08)}
-.callout.good{border-left-color: var(--good);background:rgba(99,242,161,.08)}
-.callout.bad{border-left-color: var(--bad);background:rgba(255,107,107,.08)}
-.kpi{display:flex;gap:12px;flex-wrap:wrap}
-.kpi .item{flex:1;min-width:160px;border:1px solid var(--border);border-radius:12px;padding:12px;background:rgba(255,255,255,.03)}
-.kpi .item .n{font-size:22px;font-weight:700}
-.kpi .item .t{color:var(--muted);font-size:12px}
-.footer{color:var(--muted);font-size:12px;margin:18px 0 0}
-.small{font-size:12px;color:var(--muted)}
-</style>
+  <meta name="color-scheme" content="dark" />
+  <title>実装仕様書 | SIRIUS</title>
+  <link rel="stylesheet" href="sirius-theme.css">
 </head>
-<body>
-  <div class="container">
+<body class="sirius-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS Course | タロット占いフルスタック</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">トップページ</a>
+          <a href="overview.html">概要</a>
+          <a class="active" href="implement_spec.html">実装仕様書</a>
+          <a href="issues.html">Issue集</a>
+          <a href="spec.html">動く仕様書</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>仕様を試す</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a href="overview.html">概要</a>
+        <a class="active" href="implement_spec.html">実装仕様書</a>
+        <a href="issues.html">Issue集</a>
+        <a href="spec.html">動く仕様書</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>仕様を試す</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="container content-stack">
+<div class="container">
     <div class="header">
       <div class="brand">
         <h1>実装仕様書</h1>
@@ -417,5 +406,8 @@ def test_draw_cards_seed_reproducible():
       <div class="small">注意：占い結果は娯楽目的です。医療・法律・投資などの重要判断には使用しないでください。</div>
     </div>
   </div>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
 </body>
 </html>

--- a/tu/issues.html
+++ b/tu/issues.html
@@ -3,70 +3,59 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>GitHub Issue集（Codexプロンプト集）</title>
-  <style>
-:root{
-  --bg:#0b1020;
-  --panel:#111a33;
-  --text:#eef2ff;
-  --muted:#b8c0ff;
-  --accent:#7c5cff;
-  --accent2:#35d0ba;
-  --warn:#ffcc66;
-  --bad:#ff6b6b;
-  --good:#63f2a1;
-  --code:#0a0f1f;
-  --border:rgba(255,255,255,.12);
-  --shadow: 0 8px 24px rgba(0,0,0,.35);
-}
-*{box-sizing:border-box}
-html,body{margin:0;padding:0;background:linear-gradient(180deg, var(--bg), #050714);color:var(--text);font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;line-height:1.6}
-a{color:var(--accent2);text-decoration:none}
-a:hover{text-decoration:underline}
-.container{max-width:1100px;margin:0 auto;padding:24px}
-.header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin:12px 0 18px}
-.brand h1{font-size:22px;margin:0}
-.brand p{margin:6px 0 0;color:var(--muted);font-size:13px}
-.nav{display:flex;flex-wrap:wrap;gap:10px;justify-content:flex-end}
-.nav a{display:inline-block;padding:8px 12px;border:1px solid var(--border);border-radius:999px;background:rgba(255,255,255,.03)}
-.nav a.active{border-color:rgba(124,92,255,.8);box-shadow: 0 0 0 3px rgba(124,92,255,.15) inset}
-.card{background:rgba(255,255,255,.04);border:1px solid var(--border);border-radius:14px;padding:18px;box-shadow:var(--shadow);margin:14px 0}
-.card h2{margin:0 0 10px;font-size:18px}
-.card h3{margin:16px 0 8px;font-size:15px}
-.badge{display:inline-block;padding:2px 10px;border-radius:999px;border:1px solid var(--border);background:rgba(255,255,255,.03);color:var(--muted);font-size:12px}
-.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:14px}
-.col-6{grid-column:span 6}
-.col-4{grid-column:span 4}
-.col-8{grid-column:span 8}
-.col-12{grid-column:span 12}
-@media (max-width: 920px){
-  .col-6,.col-4,.col-8{grid-column:span 12}
-  .header{flex-direction:column;align-items:stretch}
-  .nav{justify-content:flex-start}
-}
-hr{border:0;border-top:1px solid var(--border);margin:16px 0}
-ul{margin:8px 0 8px 22px}
-li{margin:4px 0}
-table{width:100%;border-collapse:collapse;border:1px solid var(--border);border-radius:12px;overflow:hidden}
-th,td{padding:10px 10px;border-bottom:1px solid var(--border);vertical-align:top}
-th{background:rgba(255,255,255,.05);text-align:left;font-weight:600}
-tr:last-child td{border-bottom:0}
-pre{background:var(--code);border:1px solid var(--border);padding:12px;border-radius:12px;overflow:auto}
-code{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto Sans Mono", monospace;font-size: 12.5px}
-.callout{border-left:4px solid var(--accent);padding:12px 14px;background:rgba(124,92,255,.08);border-radius:12px}
-.callout.warn{border-left-color: var(--warn);background:rgba(255,204,102,.08)}
-.callout.good{border-left-color: var(--good);background:rgba(99,242,161,.08)}
-.callout.bad{border-left-color: var(--bad);background:rgba(255,107,107,.08)}
-.kpi{display:flex;gap:12px;flex-wrap:wrap}
-.kpi .item{flex:1;min-width:160px;border:1px solid var(--border);border-radius:12px;padding:12px;background:rgba(255,255,255,.03)}
-.kpi .item .n{font-size:22px;font-weight:700}
-.kpi .item .t{color:var(--muted);font-size:12px}
-.footer{color:var(--muted);font-size:12px;margin:18px 0 0}
-.small{font-size:12px;color:var(--muted)}
-</style>
+  <meta name="color-scheme" content="dark" />
+  <title>GitHub Issue集 | SIRIUS</title>
+  <link rel="stylesheet" href="sirius-theme.css">
 </head>
-<body>
-  <div class="container">
+<body class="sirius-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS Course | タロット占いフルスタック</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">トップページ</a>
+          <a href="overview.html">概要</a>
+          <a href="implement_spec.html">実装仕様書</a>
+          <a class="active" href="issues.html">Issue集</a>
+          <a href="spec.html">動く仕様書</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>仕様を試す</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a href="overview.html">概要</a>
+        <a href="implement_spec.html">実装仕様書</a>
+        <a class="active" href="issues.html">Issue集</a>
+        <a href="spec.html">動く仕様書</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>仕様を試す</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="container content-stack">
+<div class="container">
     <div class="header">
       <div class="brand">
         <h1>GitHub Issue集（Codexプロンプト集）</h1>
@@ -310,5 +299,8 @@ code{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto S
       <div class="small">注意：占い結果は娯楽目的です。医療・法律・投資などの重要判断には使用しないでください。</div>
     </div>
   </div>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
 </body>
 </html>

--- a/tu/overview.html
+++ b/tu/overview.html
@@ -3,70 +3,59 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>概要・アーキテクチャ</title>
-  <style>
-:root{
-  --bg:#0b1020;
-  --panel:#111a33;
-  --text:#eef2ff;
-  --muted:#b8c0ff;
-  --accent:#7c5cff;
-  --accent2:#35d0ba;
-  --warn:#ffcc66;
-  --bad:#ff6b6b;
-  --good:#63f2a1;
-  --code:#0a0f1f;
-  --border:rgba(255,255,255,.12);
-  --shadow: 0 8px 24px rgba(0,0,0,.35);
-}
-*{box-sizing:border-box}
-html,body{margin:0;padding:0;background:linear-gradient(180deg, var(--bg), #050714);color:var(--text);font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;line-height:1.6}
-a{color:var(--accent2);text-decoration:none}
-a:hover{text-decoration:underline}
-.container{max-width:1100px;margin:0 auto;padding:24px}
-.header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin:12px 0 18px}
-.brand h1{font-size:22px;margin:0}
-.brand p{margin:6px 0 0;color:var(--muted);font-size:13px}
-.nav{display:flex;flex-wrap:wrap;gap:10px;justify-content:flex-end}
-.nav a{display:inline-block;padding:8px 12px;border:1px solid var(--border);border-radius:999px;background:rgba(255,255,255,.03)}
-.nav a.active{border-color:rgba(124,92,255,.8);box-shadow: 0 0 0 3px rgba(124,92,255,.15) inset}
-.card{background:rgba(255,255,255,.04);border:1px solid var(--border);border-radius:14px;padding:18px;box-shadow:var(--shadow);margin:14px 0}
-.card h2{margin:0 0 10px;font-size:18px}
-.card h3{margin:16px 0 8px;font-size:15px}
-.badge{display:inline-block;padding:2px 10px;border-radius:999px;border:1px solid var(--border);background:rgba(255,255,255,.03);color:var(--muted);font-size:12px}
-.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:14px}
-.col-6{grid-column:span 6}
-.col-4{grid-column:span 4}
-.col-8{grid-column:span 8}
-.col-12{grid-column:span 12}
-@media (max-width: 920px){
-  .col-6,.col-4,.col-8{grid-column:span 12}
-  .header{flex-direction:column;align-items:stretch}
-  .nav{justify-content:flex-start}
-}
-hr{border:0;border-top:1px solid var(--border);margin:16px 0}
-ul{margin:8px 0 8px 22px}
-li{margin:4px 0}
-table{width:100%;border-collapse:collapse;border:1px solid var(--border);border-radius:12px;overflow:hidden}
-th,td{padding:10px 10px;border-bottom:1px solid var(--border);vertical-align:top}
-th{background:rgba(255,255,255,.05);text-align:left;font-weight:600}
-tr:last-child td{border-bottom:0}
-pre{background:var(--code);border:1px solid var(--border);padding:12px;border-radius:12px;overflow:auto}
-code{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto Sans Mono", monospace;font-size: 12.5px}
-.callout{border-left:4px solid var(--accent);padding:12px 14px;background:rgba(124,92,255,.08);border-radius:12px}
-.callout.warn{border-left-color: var(--warn);background:rgba(255,204,102,.08)}
-.callout.good{border-left-color: var(--good);background:rgba(99,242,161,.08)}
-.callout.bad{border-left-color: var(--bad);background:rgba(255,107,107,.08)}
-.kpi{display:flex;gap:12px;flex-wrap:wrap}
-.kpi .item{flex:1;min-width:160px;border:1px solid var(--border);border-radius:12px;padding:12px;background:rgba(255,255,255,.03)}
-.kpi .item .n{font-size:22px;font-weight:700}
-.kpi .item .t{color:var(--muted);font-size:12px}
-.footer{color:var(--muted);font-size:12px;margin:18px 0 0}
-.small{font-size:12px;color:var(--muted)}
-</style>
+  <meta name="color-scheme" content="dark" />
+  <title>概要・アーキテクチャ | SIRIUS</title>
+  <link rel="stylesheet" href="sirius-theme.css">
 </head>
-<body>
-  <div class="container">
+<body class="sirius-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS Course | タロット占いフルスタック</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">トップページ</a>
+          <a class="active" href="overview.html">概要</a>
+          <a href="implement_spec.html">実装仕様書</a>
+          <a href="issues.html">Issue集</a>
+          <a href="spec.html">動く仕様書</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>仕様を試す</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a class="active" href="overview.html">概要</a>
+        <a href="implement_spec.html">実装仕様書</a>
+        <a href="issues.html">Issue集</a>
+        <a href="spec.html">動く仕様書</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>仕様を試す</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="container content-stack">
+<div class="container">
     <div class="header">
       <div class="brand">
         <h1>概要・アーキテクチャ</h1>
@@ -196,5 +185,8 @@ code{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto S
       <div class="small">注意：占い結果は娯楽目的です。医療・法律・投資などの重要判断には使用しないでください。</div>
     </div>
   </div>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
 </body>
 </html>

--- a/tu/sirius-theme.css
+++ b/tu/sirius-theme.css
@@ -1,0 +1,362 @@
+@import url("../bt30/altair-theme.css");
+
+:root {
+  color-scheme: dark;
+}
+
+body.sirius-page {
+  margin: 0;
+  font-family: "Inter", "Hiragino Sans", "Noto Sans JP", system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 700px at 70% 10%, rgba(167, 139, 250, 0.2), transparent 55%),
+    radial-gradient(900px 560px at 20% 25%, rgba(124, 247, 255, 0.16), transparent 55%),
+    radial-gradient(760px 560px at 80% 60%, rgba(255, 94, 168, 0.1), transparent 60%),
+    linear-gradient(180deg, var(--bg0), var(--bg1) 45%, var(--bg2));
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+}
+
+.wrap {
+  position: relative;
+  z-index: 2;
+  width: min(var(--max), calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.skip {
+  position: absolute;
+  left: -999px;
+  top: 14px;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.82);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  z-index: 9999;
+}
+
+.skip:focus {
+  left: 16px;
+}
+
+.navlinks a.active {
+  color: var(--text);
+  border-color: rgba(124, 247, 255, 0.32);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 0 3px rgba(124, 247, 255, 0.18) inset;
+}
+
+.course-header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sirius-hero {
+  margin: 16px 0 12px;
+  display: grid;
+  gap: 14px;
+}
+
+.sirius-hero .page-header {
+  margin: 0;
+}
+
+.sirius-hero .lede {
+  margin-top: 10px;
+  color: var(--muted);
+  line-height: 1.8;
+  max-width: 78ch;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.meta-card {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.28);
+  padding: 12px;
+  border-radius: 14px;
+  color: var(--muted);
+}
+
+.meta-card strong {
+  display: block;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: 0.01em;
+}
+
+.content-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 12px 0 18px;
+}
+
+.header .nav {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.card {
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -80px;
+  background:
+    radial-gradient(420px 180px at 20% 20%, rgba(124, 247, 255, 0.1), transparent 60%),
+    radial-gradient(420px 160px at 80% 70%, rgba(167, 139, 250, 0.09), transparent 62%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 14px;
+}
+
+.col-4 { grid-column: span 4; }
+.col-6 { grid-column: span 6; }
+.col-8 { grid-column: span 8; }
+.col-12 { grid-column: span 12; }
+
+@media (max-width: 960px) {
+  .col-4, .col-6, .col-8 { grid-column: span 12; }
+}
+
+.callout {
+  border-left: 4px solid var(--accent);
+  padding: 12px 14px;
+  background: rgba(124, 247, 255, 0.08);
+  border-radius: 12px;
+  color: var(--muted);
+}
+
+.callout.warn { border-left-color: var(--gold); background: rgba(255, 211, 110, 0.1); }
+.callout.good { border-left-color: #63f2a1; background: rgba(99, 242, 161, 0.12); }
+.callout.bad { border-left-color: #ff6b6b; background: rgba(255, 107, 107, 0.12); }
+
+.kpi {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.kpi .item {
+  flex: 1;
+  min-width: 160px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.kpi .item .n { font-size: 22px; font-weight: 700; }
+.kpi .item .t { color: var(--muted); font-size: 12px; }
+
+.table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 12px 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+th, td {
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+th { background: rgba(255, 255, 255, 0.04); color: var(--text); }
+tr:nth-child(even) td { background: rgba(255, 255, 255, 0.02); }
+tr:last-child td { border-bottom: 0; }
+
+pre {
+  background: rgba(0, 0, 0, 0.45);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 12px;
+  overflow-x: auto;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.25);
+}
+
+code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 2px 6px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+}
+
+.small { font-size: 12px; color: var(--muted); }
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 10px;
+  margin: 8px 0;
+}
+
+.c12 { grid-column: span 12; }
+.c6 { grid-column: span 6; }
+
+@media (max-width: 820px) {
+  .c6 { grid-column: span 12; }
+}
+
+.input, select, textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  outline: none;
+}
+
+textarea { min-height: 110px; }
+
+button,
+button.secondary {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(124, 247, 255, 0.8);
+  background: linear-gradient(135deg, rgba(124, 247, 255, 0.24), rgba(167, 139, 250, 0.18));
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.4);
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.cardlist {
+  display: grid;
+  gap: 10px;
+  margin: 10px 0;
+}
+
+.cardlist .item {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.footer-note {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 12px;
+  margin-top: 14px;
+  color: var(--muted);
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+.pill .spark {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, var(--gold), rgba(255, 211, 110, 0.18));
+  box-shadow: 0 0 18px rgba(255, 211, 110, 0.35);
+}
+
+@media (max-width: 720px) {
+  table {
+    display: block;
+  }
+
+  table thead,
+  table tbody,
+  table tr {
+    display: table;
+    width: 100%;
+  }
+}

--- a/tu/spec.html
+++ b/tu/spec.html
@@ -3,70 +3,59 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>動く仕様書（JavaScriptで実行）</title>
-  <style>
-:root{
-  --bg:#0b1020;
-  --panel:#111a33;
-  --text:#eef2ff;
-  --muted:#b8c0ff;
-  --accent:#7c5cff;
-  --accent2:#35d0ba;
-  --warn:#ffcc66;
-  --bad:#ff6b6b;
-  --good:#63f2a1;
-  --code:#0a0f1f;
-  --border:rgba(255,255,255,.12);
-  --shadow: 0 8px 24px rgba(0,0,0,.35);
-}
-*{box-sizing:border-box}
-html,body{margin:0;padding:0;background:linear-gradient(180deg, var(--bg), #050714);color:var(--text);font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;line-height:1.6}
-a{color:var(--accent2);text-decoration:none}
-a:hover{text-decoration:underline}
-.container{max-width:1100px;margin:0 auto;padding:24px}
-.header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin:12px 0 18px}
-.brand h1{font-size:22px;margin:0}
-.brand p{margin:6px 0 0;color:var(--muted);font-size:13px}
-.nav{display:flex;flex-wrap:wrap;gap:10px;justify-content:flex-end}
-.nav a{display:inline-block;padding:8px 12px;border:1px solid var(--border);border-radius:999px;background:rgba(255,255,255,.03)}
-.nav a.active{border-color:rgba(124,92,255,.8);box-shadow: 0 0 0 3px rgba(124,92,255,.15) inset}
-.card{background:rgba(255,255,255,.04);border:1px solid var(--border);border-radius:14px;padding:18px;box-shadow:var(--shadow);margin:14px 0}
-.card h2{margin:0 0 10px;font-size:18px}
-.card h3{margin:16px 0 8px;font-size:15px}
-.badge{display:inline-block;padding:2px 10px;border-radius:999px;border:1px solid var(--border);background:rgba(255,255,255,.03);color:var(--muted);font-size:12px}
-.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:14px}
-.col-6{grid-column:span 6}
-.col-4{grid-column:span 4}
-.col-8{grid-column:span 8}
-.col-12{grid-column:span 12}
-@media (max-width: 920px){
-  .col-6,.col-4,.col-8{grid-column:span 12}
-  .header{flex-direction:column;align-items:stretch}
-  .nav{justify-content:flex-start}
-}
-hr{border:0;border-top:1px solid var(--border);margin:16px 0}
-ul{margin:8px 0 8px 22px}
-li{margin:4px 0}
-table{width:100%;border-collapse:collapse;border:1px solid var(--border);border-radius:12px;overflow:hidden}
-th,td{padding:10px 10px;border-bottom:1px solid var(--border);vertical-align:top}
-th{background:rgba(255,255,255,.05);text-align:left;font-weight:600}
-tr:last-child td{border-bottom:0}
-pre{background:var(--code);border:1px solid var(--border);padding:12px;border-radius:12px;overflow:auto}
-code{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Noto Sans Mono", monospace;font-size: 12.5px}
-.callout{border-left:4px solid var(--accent);padding:12px 14px;background:rgba(124,92,255,.08);border-radius:12px}
-.callout.warn{border-left-color: var(--warn);background:rgba(255,204,102,.08)}
-.callout.good{border-left-color: var(--good);background:rgba(99,242,161,.08)}
-.callout.bad{border-left-color: var(--bad);background:rgba(255,107,107,.08)}
-.kpi{display:flex;gap:12px;flex-wrap:wrap}
-.kpi .item{flex:1;min-width:160px;border:1px solid var(--border);border-radius:12px;padding:12px;background:rgba(255,255,255,.03)}
-.kpi .item .n{font-size:22px;font-weight:700}
-.kpi .item .t{color:var(--muted);font-size:12px}
-.footer{color:var(--muted);font-size:12px;margin:18px 0 0}
-.small{font-size:12px;color:var(--muted)}
-</style>
+  <meta name="color-scheme" content="dark" />
+  <title>動く仕様書（JavaScriptで実行） | SIRIUS</title>
+  <link rel="stylesheet" href="sirius-theme.css">
 </head>
-<body>
-  <div class="container">
+<body class="sirius-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS Course | タロット占いフルスタック</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">トップページ</a>
+          <a href="overview.html">概要</a>
+          <a href="implement_spec.html">実装仕様書</a>
+          <a href="issues.html">Issue集</a>
+          <a class="active" href="spec.html">動く仕様書</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="#main"><span class="dot" aria-hidden="true"></span>実行エリアへ</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">トップページ</a>
+        <a href="overview.html">概要</a>
+        <a href="implement_spec.html">実装仕様書</a>
+        <a href="issues.html">Issue集</a>
+        <a class="active" href="spec.html">動く仕様書</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="#main"><span class="dot" aria-hidden="true"></span>実行エリアへ</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="container content-stack">
+<div class="container">
     <div class="header">
       <div class="brand">
         <h1>動く仕様書（JavaScriptで実行）</h1>
@@ -2106,5 +2095,8 @@ document.getElementById("question").value = "今の自分に必要なメッセ�
       <div class="small">注意：占い結果は娯楽目的です。医療・法律・投資などの重要判断には使用しないでください。</div>
     </div>
   </div>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add the new SIRIUS course to the top page with links to the tarot (tu) documentation set
- Wrap the SIRIUS pages with the shared dark header, starfield canvas, and consistent navigation for better contrast
- Introduce a reusable SIRIUS theme (based on the ALTAIR look) that improves table responsiveness and text legibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd5328fe88333992413f9ef86dd3b)