### PR TITLE
Add backlog folder with SIRIUS issue outlines

### DIFF
--- a/backlog/README.md
+++ b/backlog/README.md
@@ -1,0 +1,10 @@
+# Backlog
+
+会議で決定したBacklogを、S列（Projects列）ごとに整理しています。各ファイルのコードブロックを GitHub Issue にコピペして活用してください。
+
+- [S-GP（導線 / UI）](S-GP.md)
+- [S-EVAL（採点 / 強制ゲート / CI）](S-EVAL.md)
+- [S-ENV（環境 / 世界 / 仕様）](S-ENV.md)
+- [S-CUR（カリキュラム / ミッション）](S-CUR.md)
+- [S-OBS（観測 / ログ / Goldilocks制御）](S-OBS.md)
+- [S-BIZ（最大収益の代理目的 / 推薦）](S-BIZ.md)

--- a/backlog/S-BIZ.md
+++ b/backlog/S-BIZ.md
@@ -1,0 +1,67 @@
+# S-BIZ（最大収益の代理目的 / 推薦）
+
+```md
+TITLE: [SIRIUS][S-BIZ][P2] 収益/継続を最大化する “次ミッション推薦” の報酬設計 + バンディット実装（デモ/テスト付き）
+LABELS: course:sirius, S-BIZ, priority:P2
+S_COLUMN: S-BIZ
+DEPENDS_ON: Issue05（推奨）+ Issue10（あると強い）
+EST_SIZE: M
+A(S) COVERED: biz.01, biz.02, obs.03
+
+## S（Spec）/ 仕様
+目的：
+- 「何を最大化すると最大収益に近づくか」をコース内に明文化し、計測→推薦→改善のループを作る。
+- 実装はまず軽量な “コンテキスト付きバンディット” で良い（運用コストが低い）。
+
+North Star（暫定・代理目的）：
+- 期待LTVの代理として：
+  - R = +1.0（次ミッション合格）
+  - R = +0.2（提出まで到達）
+  - R = -0.5（連続Fail/タイムアウト/離脱）
+  - R = -0.1 * log(計算コスト+1)（CI時間・試行回数の代理）
+- 目的：E[R] を最大化（= 継続/修了率を上げつつコストを抑える）
+
+実装要件：
+- sirius_rl/recommend/bandit_recommender.py
+  - context: { last_outcome, time_spent, trials, mastery_estimate } など（最初は簡単でOK）
+  - arms: 次に出すミッション（例: bandit_easy/bandit_hard/gridworld_dp/q_learning）やガイドLv
+  - algorithm: Thompson sampling（Beta-Bernoulli）または簡易LinUCB
+- デモ:
+  - scripts/sim_recommender.py（擬似ユーザで比較）
+- テスト:
+  - 擬似環境で “ランダム推薦より平均報酬が高い” を統計的に確認（flaky注意）
+
+受け入れ基準：
+- [ ] reward設計（上記）が docs/rl/G_W_E_S_A.md に追記されている
+- [ ] recommender 実装 + シミュレーションが動く
+- [ ] pytest で最低限の検証が通る（flakyにしない）
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたは「最大収益（の代理）を最適化する推薦」を、教育用途の軽量実装で作ります。
+
+手順：
+1) docs/rl/G_W_E_S_A.md に “North Star と Reward設計” セクションを追記。
+   - 収益の代理として継続/修了/コストを使うことを明記。
+2) sirius_rl/recommend/bandit_recommender.py を追加。
+   - arms を最低3つ列挙
+   - API: recommend(context)->arm / update(context, arm, reward)
+   - アルゴリズムは Beta-Bernoulli Thompson Sampling でOK
+   - コンテキストは最初は「ビニング」でもOK（例：mastery_low/mid/high）
+3) scripts/sim_recommender.py を追加。
+   - 擬似ユーザモデル（難しすぎると失敗、易しすぎると飽きる）を実装
+   - random vs recommender で平均報酬を比較して表示
+4) tests/test_recommender.py を追加。
+   - seed固定 + 複数seed平均で random より期待報酬が高いことを確認
+   - flaky回避：閾値に余裕、試行回数を調整
+5) （任意）rl/overview.html に「推薦はBanditで作れる」短い説明を追記。
+
+注意：
+- “課金”の実装はしない（設計と計測と推薦の形を作る）。
+~~~ 
+
+## Definition of Done
+- [ ] Reward設計がdocsに入る
+- [ ] recommender + sim + test
+- [ ] CI green
+```

--- a/backlog/S-CUR.md
+++ b/backlog/S-CUR.md
@@ -1,0 +1,113 @@
+# S-CUR（カリキュラム / ミッション）
+
+```md
+TITLE: [SIRIUS][S-CUR][P0] Mission1: Banditアルゴリズム（ε-greedy/UCB/Thompson）+ 合格テスト（統計的）
+LABELS: course:sirius, S-CUR, priority:P0
+S_COLUMN: S-CUR
+DEPENDS_ON: Issue04
+EST_SIZE: M
+A(S) COVERED: cur.bandit.01, eval.bandit.01
+
+## S（Spec）/ 仕様
+目的：
+- “強化学習スキル獲得” の最短入口として、探索と活用の基本を課題化する。
+- 確率タスクなので合格判定は「複数seed平均」など統計的にする（CIで安定させる）。
+
+実装対象（提案）：
+- sirius_rl/agents/bandit.py
+  - EpsilonGreedyAgent
+  - UCB1Agent
+  - ThompsonSamplingBernoulliAgent（Beta-Bernoulli）
+- sirius_rl/eval/bandit_bench.py
+  - 複数seedで平均regret/平均rewardを返す
+
+合格条件（例：CI安定優先で後で調整OK）：
+- 固定probs（例: [0.1,0.2,0.8,0.4,0.3]）
+- T=300〜800, seeds=5〜10 で
+  - random baseline より平均regretが小さい（相対評価）
+  - 例：ε-greedy <= baseline*0.75、UCB <= ε-greedy*0.95 など
+
+受け入れ基準：
+- [ ] 3アルゴリズムが動作
+- [ ] 複数seed平均で評価できる
+- [ ] pytestで合格判定が安定して通る
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはBanditの学習アルゴリズム課題を実装します。外部RLライブラリは禁止（学習用に自前実装）。
+
+手順：
+1) sirius_rl/agents/bandit.py を新規作成（または既存に追加）。
+   - Agentは (obs)->action を返せる形
+   - update(action, reward) を持たせてもよい（runner側で呼ぶ）
+2) eval/bandit_bench.py に run_bandit_benchmark(env, agent, seeds, T) を作り、
+   - 平均reward、平均regret を返す。
+3) tests/test_bandit_agents.py を追加：
+   - 固定probs環境で random baseline と比較して、相対的に良いことをassert
+   - flaky回避：seedsを複数、閾値に余裕、Tは短めから
+4) rl/index.html に「Mission1: Bandit」章を追記：
+   - 目的、提出物（対象ファイル/クラス）、合格の考え方
+
+注意：
+- CIで落ちない（flakyにしない）のが最優先。
+~~~ 
+
+## Definition of Done
+- [ ] 3エージェント実装
+- [ ] ベンチ + テスト追加
+- [ ] rl/index.html 更新
+```
+
+```md
+TITLE: [SIRIUS][S-CUR][P1] Mission2: 表形式Q-learning（+SARSA任意）+ 合格テスト
+LABELS: course:sirius, S-CUR, priority:P1
+S_COLUMN: S-CUR
+DEPENDS_ON: Issue06
+EST_SIZE: M
+A(S) COVERED: cur.td.01, eval.td.01
+
+## S（Spec）/ 仕様
+目的：
+- “モデルフリー強化学習” の基本として、Q-learning をGridWorldで動かし、学習で方策が改善することを体験できるようにする。
+
+仕様（提案）：
+- sirius_rl/algorithms/td.py
+  - q_learning(env, episodes, alpha, gamma, epsilon_schedule, seed) -> Q
+  - derive_greedy_policy(Q) -> policy
+- 評価:
+  - 学習後の greedy policy を Nエピソード評価して成功率/平均報酬を測る
+
+合格条件（例）：
+- 固定GridWorldで、学習後の成功率 >= 0.8（seeds複数で平均）
+
+受け入れ基準：
+- [ ] Q-learning 実装
+- [ ] 学習→評価のハーネスがある
+- [ ] pytest が安定して通る
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはQ-learning課題を実装します。
+
+手順：
+1) sirius_rl/algorithms/td.py を追加し、q_learning を実装。
+   - 状態は離散 int（GridWorldのstate_id）
+   - 行動数は env から取得
+2) epsilon は定数でも良いが、可能なら線形減衰スケジュールを用意（簡単でOK）。
+3) 評価関数を追加：
+   - eval/td_eval.py 等に policy をGridWorldで回して成功率/平均報酬を返す関数
+4) tests/test_q_learning.py を追加：
+   - episodesはCI時間に合わせる（例：500〜2000）
+   - seeds複数（例：3〜5）で平均成功率が閾値超え
+   - 環境はできるだけ決定論に（flaky回避）
+5) rl/index.html に Mission2 の提出物と合格条件（概念）を追記。
+
+注意：
+- 速度と安定性重視。学習が遅い場合は環境/報酬/episodesを調整してテストを安定化。
+~~~ 
+
+## Definition of Done
+- [ ] td.py 実装
+- [ ] eval + テスト
+- [ ] rl/index.html 更新
+```

--- a/backlog/S-ENV.md
+++ b/backlog/S-ENV.md
@@ -1,0 +1,175 @@
+# S-ENV（環境 / 世界 / 仕様）
+
+```md
+TITLE: [SIRIUS][S-ENV][P0] RLコア基盤（Envインターフェース/seed/ログ/評価ハーネス）を追加
+LABELS: course:sirius, S-ENV, priority:P0
+S_COLUMN: S-ENV
+DEPENDS_ON: Issue02
+EST_SIZE: M
+A(S) COVERED: env.00, env.01, obs.00
+
+## S（Spec）/ 仕様
+目的：
+- RL課題で必須の「環境API契約」「seed再現」「ログ」「評価」の共通基盤を先に固める。
+- 後続の Bandit / GridWorld / Q-learning が同じ枠で動く状態にする。
+
+成果物（例：既存構成に合わせて調整OK）：
+- sirius_rl/（または既存のPython構成に合わせたパッケージ）
+  - env/base.py : Environmentプロトコル（reset(seed), step(action)）
+  - utils/seed.py : RNG管理
+  - utils/logging.py : 学習ログ共通フォーマット（JSON Lines推奨）
+  - eval/runner.py : “方策/アルゴリズム”を与えてNステップ回す評価関数
+- tests/
+  - test_seed_repro.py : seedで再現すること
+  - test_log_schema.py : ログスキーマが壊れないこと
+
+受け入れ基準：
+- [ ] `pytest` が通る
+- [ ] 同一seedなら評価結果が一致する（少なくとも同一env+policyで）
+- [ ] ログが一定スキーマで出る（最低: seed / step / reward / info）
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはRL用のPython共通基盤を実装します。外部依存は最小。
+
+手順：
+1) 既存Python構成を確認（src/配下 or 直下パッケージ、pyproject/requirements）。
+   - 既存流儀に合わせて sirius_rl/ を配置。
+2) Envインターフェースを定義：
+   - reset(seed: int | None) -> obs
+   - step(action) -> (obs, reward: float, terminated: bool, info: dict)
+   - 可能なら dataclass StepResult でもOK
+3) seed管理：
+   - numpy.random.Generator か random を使う（どちらかに統一）
+   - envが内部にRNGを保持し、reset(seed)で再初期化する
+4) ログ：
+   - jsonl で append できる logger を用意
+   - schema例: { "run_id":..., "seed":..., "t":..., "episode":..., "reward":..., "info":... }
+5) 評価runner：
+   - agent（callable: obs->action）と env を渡して N step/episode 実行
+   - cumulative reward 等を返す
+6) tests：
+   - seed固定でrunner結果が一致するテスト
+   - loggerが必須フィールドを出すテスト
+
+注意：
+- CI時間を食わない。
+- 後続IssueでBandit/GridWorldを載せるので拡張しやすい形にする。
+~~~ 
+
+## Definition of Done
+- [ ] Env interface + seed + logger + runner 実装
+- [ ] pytest green
+- [ ] 簡単な使い方を docs/rl/G_W_E_S_A.md か rl/overview.html に追記
+```
+
+```md
+TITLE: [SIRIUS][S-ENV][P0] Multi-Armed Bandit環境 + regret評価 + 再現テスト
+LABELS: course:sirius, S-ENV, priority:P0
+S_COLUMN: S-ENV
+DEPENDS_ON: Issue03
+EST_SIZE: M
+A(S) COVERED: env.02, env.03, eval.bandit.00
+
+## S（Spec）/ 仕様
+目的：
+- 最小のRL世界として Bandit を実装し、以後のアルゴリズム課題（ε-greedy/UCB/TS）の土台にする。
+- 確率性があるので “再現性” と “評価” を最初からテストで担保する。
+
+仕様（提案）：
+- BernoulliBanditEnv(K, probs, seed)
+  - action: 0..K-1
+  - reward: {0,1}（Bernoulli）
+  - obs: None でもOK（簡単で良い）
+- regret計算：
+  - best_prob = max(probs)
+  - expected_regret += best_prob - probs[action]
+- baseline：
+  - random policy baseline（固定seedで）
+
+受け入れ基準：
+- [ ] 同一seedでbanditの報酬系列が再現する
+- [ ] regret計算が正しい（ユニットテスト）
+- [ ] 評価関数で baseline の平均reward/regret が取れる
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはBandit環境を実装します。
+
+手順：
+1) Issue03のEnvインターフェースに準拠し、sirius_rl/env/bandit.py を追加。
+2) BernoulliBanditEnv を実装：
+   - probs: list[float] を受け取り 0<=p<=1 をvalidate
+   - reset(seed)でRNG初期化
+   - step(action)で Bernoulli(p[action]) をサンプルして reward を返す
+   - terminated は常に False（ステップタスク）でOK
+3) regret計算ユーティリティを追加（1箇所にまとめる）。
+4) tests：
+   - seed固定でNステップ回した reward 列が一致するテスト
+   - regret計算が正しいテスト（手計算できるケース）
+5) rl/overview.html に Bandit（状態/行動/報酬/目的）を追記。
+
+注意：
+- テストは軽く（N小さく、seed固定）。
+~~~ 
+
+## Definition of Done
+- [ ] bandit env + regret + baseline
+- [ ] pytest green
+- [ ] rl/overview.html 更新
+```
+
+```md
+TITLE: [SIRIUS][S-ENV][P1] GridWorld環境 + 動的計画法（Value Iteration / Policy Iteration）+ テスト
+LABELS: course:sirius, S-ENV, priority:P1
+S_COLUMN: S-ENV
+DEPENDS_ON: Issue03
+EST_SIZE: M
+A(S) COVERED: env.04, cur.dp.00
+
+## S（Spec）/ 仕様
+目的：
+- Banditの次として “状態があるMDP” を実装し、価値反復/方策反復を学べる土台を作る。
+
+仕様（提案）：
+- GridWorldEnv(width,height,walls,start,terminals,reward_map,step_penalty)
+  - action: 0..3（上下左右）
+  - 遷移: 基本は決定論（壁ならその場）
+  - terminated: terminal到達で True
+- DP:
+  - value_iteration(env, gamma, theta) -> V, policy
+  - policy_iteration(env, gamma) -> V, policy
+
+受け入れ基準：
+- [ ] 小さなGridで最適方策が期待どおりになる
+- [ ] `pytest` が安定して通る
+- [ ] rl/overview.html に MDP(状態/行動/遷移/報酬/割引) の説明がある
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはGridWorldとDPアルゴリズムを実装します（教育用途・小さな状態数でOK）。
+
+手順：
+1) sirius_rl/env/gridworld.py を追加し、Envインターフェースに従う。
+   - reset(seed)で開始状態へ
+   - step(action)で次状態、報酬、terminated、infoを返す
+   - 離散状態を int state_id として扱えるようにする（例：y*W+x）
+2) DP実装：sirius_rl/algorithms/dp.py を追加
+   - value_iteration と policy_iteration を実装
+   - envが “全状態・全行動の遷移/報酬” を取得できるAPIを提供する（例：env.model()）
+3) tests/test_gridworld_dp.py を追加：
+   - 例：4x4、ゴール(+1)、step_penalty(-0.01)で、スタートから最短に近い方策になることを確認
+   - 期待方策の一部一致（最初の一手など）でもOK（壊れにくいテストに）
+4) rl/overview.html にGridWorld章を追加し、DPの狙いを説明。
+
+注意：
+- 外部依存なし。
+- CI時間を食わない。
+~~~ 
+
+## Definition of Done
+- [ ] gridworld env 実装
+- [ ] dp 実装
+- [ ] テスト green
+- [ ] rl/overview.html 更新
+```

--- a/backlog/S-EVAL.md
+++ b/backlog/S-EVAL.md
@@ -1,0 +1,119 @@
+# S-EVAL（採点 / 強制ゲート / CI）
+
+```md
+TITLE: [SIRIUS][S-EVAL][P0] RLコースの G:(W,E)->(S,A(S)) / obligationカタログ / PRゲートをリポジトリに固定
+LABELS: course:sirius, S-EVAL, priority:P0
+S_COLUMN: S-EVAL
+DEPENDS_ON: なし
+EST_SIZE: S
+A(S) COVERED: eval.00, meta.00
+
+## S（Spec）/ 仕様
+目的：
+- RLコース追加を「World W」として、観点Sとobligation A(S)をドキュメント化し、以後のIssue/PRがブレない状態に固定する。
+- PRごとに影響obligation集合 A_j を書き、テスト/証拠でゲートする最小運用を標準化する。
+
+成果物（ファイル）：
+- docs/rl/G_W_E_S_A.md
+  - W（追加範囲）: RLコースページ、RL用Pythonコード、CI、デモ、ログ/メトリクス、次課題推薦
+  - E（制約）: CI時間上限、seed再現性、外部依存最小、静的サイト壊さない…等
+  - S（観点束）: S-GP/S-EVAL/S-ENV/S-CUR/S-OBS/S-BIZ
+  - A(S)（obligation族）: 本Issueセットに対応するID一覧（gp.*, eval.*, env.*, cur.*, obs.*, biz.*）
+- docs/rl/PR_GATE.md
+  - PR本文テンプレ（A_j / テスト証拠 / リスク）をコピペ可能な形で記述
+
+受け入れ基準：
+- [ ] 上記2ファイルが追加され、README または rl/index.html から辿れる
+- [ ] A(S) が Issue番号と紐づく（例：「Issue04がenv.01を満たす」）
+- [ ] PRテンプレとして貼れる「A_j セクション」が docs/rl/PR_GATE.md にある
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはこのリポジトリのメンテナです。設計ドキュメントを追加し、以後のPRがブレないようにします。
+
+手順：
+1) 既存の docs/ や各コース（bt7/qr/ec/btd 等）のドキュメント書式を確認し、同じノリに合わせる。
+2) docs/rl/ を新規作成し、以下2ファイルを追加する：
+   - docs/rl/G_W_E_S_A.md
+   - docs/rl/PR_GATE.md
+3) docs/rl/G_W_E_S_A.md に以下を記述：
+   - W/E/S の定義（短い文章でOK）
+   - S列の一覧（S-GP/S-EVAL/S-ENV/S-CUR/S-OBS/S-BIZ）
+   - obligation ID 一覧（gp.01... のように）
+   - obligation ↔ Issue番号 の対応（箇条書きでOK）
+4) docs/rl/PR_GATE.md に以下を記述：
+   - PR本文テンプレ（A_j / 実行テスト / 証拠リンク / 影響範囲 / リスク）
+   - “PRを小さくする理由” を3行で明文化（影響推定を小さく、検証を速く、学習を速く）
+5) README.md があるなら末尾に「RLコース設計ドキュメント」リンクを追記。無い場合は docs/README.md を作ってリンクを置く。
+
+注意：
+- コードは増やさない（このIssueはドキュメントのみ）。
+- 既存リンク/導線を壊さない。
+~~~ 
+
+## Definition of Done
+- [ ] docs/rl/G_W_E_S_A.md 作成
+- [ ] docs/rl/PR_GATE.md 作成
+- [ ] どこかから導線追加
+```
+
+```md
+TITLE: [SIRIUS][S-EVAL][P0] GitHub運用の最小セットを追加（Issue/PRテンプレ + python-ci）
+LABELS: course:sirius, S-EVAL, priority:P0
+S_COLUMN: S-EVAL
+DEPENDS_ON: Issue01（推奨）
+EST_SIZE: M
+A(S) COVERED: eval.01, eval.02
+
+## S（Spec）/ 仕様
+目的：
+- RLコースも「課題配布→PR提出→テスト採点」で回るように、テンプレとCIを整備する。
+- PR本文に A_j（影響obligation）と、テスト証拠を残せるようにする。
+
+成果物：
+- .github/pull_request_template.md（無ければ作成、あれば拡張）
+  - 所要時間 / 試行回数 / Outcome
+  - A_j（影響obligation ID）
+  - 実行したテスト（コマンド）と結果
+- .github/ISSUE_TEMPLATE/（任意：RL用テンプレ）
+  - Mission Issue用（目的/受け入れ基準/提出物/参考/Codex Prompt欄）
+- .github/workflows/python-ci.yml（既存があれば統合）
+  - PRで pytest + lint（ruff等）が走り、Failなら落ちる
+
+受け入れ基準：
+- [ ] PR作成でCIが自動実行される
+- [ ] PRテンプレが自動で本文に出る
+- [ ] python-ci が Pass/Fail を返す（最低1つのダミーテストでOK）
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはGitHub運用（Issue→PR→Actionsテスト）を整備します。
+
+手順：
+1) .github/ があるか確認。無ければ作成。
+2) PRテンプレを追加/更新: .github/pull_request_template.md
+   - セクション:
+     - Summary（何をしたか）
+     - Time/Trials/Outcome
+     - A_j（影響obligation IDの箇条書き）
+     - Test Evidence（実行コマンドと結果、ログの貼り方）
+3) 可能なら .github/ISSUE_TEMPLATE/sirius_mission.md を追加：
+   - Goal / Acceptance Criteria / Submission / Notes / Codex Prompt 欄
+4) CIを整備：
+   - 既に workflow があるなら、pytest と lint が走るように統合
+   - 無ければ .github/workflows/python-ci.yml を新規作成
+   - python-version は既存方針に合わせる（不明なら 3.11）
+5) Pythonのテスト基盤が無い場合：
+   - pytest を導入（requirements.txt または pyproject.toml）
+   - tests/test_smoke.py を追加してCIが必ず動く状態にする
+
+注意：
+- 既存CIがある場合は“置換”ではなく“拡張/統合”。
+- CI実行時間が長くならない構成にする。
+~~~ 
+
+## Definition of Done
+- [ ] PRテンプレ導入
+- [ ] python-ci がPRで走る
+- [ ] pytest が最低1本通る
+```

--- a/backlog/S-GP.md
+++ b/backlog/S-GP.md
@@ -1,0 +1,114 @@
+# S-GP（導線 / UI）
+
+```md
+TITLE: [SIRIUS][S-GP][P0] ホームにRLコース（SIRIUS）を追加 + rl/ の scope/index/overview/spec を作成
+LABELS: course:sirius, S-GP, priority:P0
+S_COLUMN: S-GP
+DEPENDS_ON: Issue00（推奨）
+EST_SIZE: M
+A(S) COVERED: gp.01, gp.02
+
+## S（Spec）/ 仕様
+目的：
+- index.html に RLコース（SIRIUS）のカードを追加し、既存の世界観/導線（Scope→Index→Overview→Spec）に合流させる。
+- rl/ 配下に最低限の4ページを作り、以後の環境/課題/デモを載せる土台を作る。
+
+変更対象：
+- index.html
+  - COURSESセクションに新コースカード追加（見た目は既存コースに合わせる）
+  - Shortcuts（右側）に SIRIUS を追加（任意だが推奨）
+- 新規:
+  - rl/scope.html
+  - rl/index.html
+  - rl/overview.html
+  - rl/spec.html
+
+受け入れ基準（Acceptance Criteria）：
+- [ ] index.html のコース一覧に SIRIUS が表示される
+- [ ] SIRIUSカードから4リンクが全て相対パスで開ける
+- [ ] 各 rl/*.html に「Homeへ戻る」導線と、4ページ間のナビがある
+- [ ] モバイル表示でも崩れない（既存CSS/レイアウト踏襲）
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたはこの静的サイトに新コースを追加します。既存のHTML/CSS/雰囲気を崩さずに、SIRIUS（強化学習）コース導線を作ってください。
+
+手順：
+1) リポジトリ直下の index.html を開き、既存の <article class="course"> を1つ選び、同じ構造で新コースカードを追加する。
+   - コース名: SIRIUS
+   - 目安: 「1日1時間 / 14日」（暫定）
+   - 説明: 「強化学習（Bandit→MDP→Q-learning）を、GitHub(PR)/テスト採点で攻略するコース」程度
+   - 4リンク: rl/scope.html, rl/index.html, rl/overview.html, rl/spec.html
+   - 見た目: 既存のcourseカードと同じクラス/構造を踏襲。色は既存変数を使い新規CSS変数を増やさない。
+2) Shortcuts（右側の<ul>）にも SIRIUS を追加（可能なら）。リンクは rl/index.html。
+3) rl/ ディレクトリを作成し、4ファイルを追加する。
+   - 既存コースの各ページ（bt7/scope.html, qr/index.html 等）があるなら、同じ骨格（header/nav/section）をコピーしてタイトル/本文だけ差し替える。
+   - 4ページ共通で上部にナビ（Scope/Index/Overview/Spec）と Home リンクを置く。
+4) rl/index.html には GitHub運用（Issue→PR→テスト採点）を短く説明し、Mission一覧（プレースホルダ）を置く。
+5) すべてのリンクが相対パスで正しいことを確認する。
+
+注意：
+- 既存コース（VEGA/ALTAIR/DENEB/SPICA/RIGEL）やCSSを壊さない。
+- まずはプレースホルダでOKだが、見出し構造（h1/h2）と導線は必須。
+~~~ 
+
+## Definition of Done
+- [ ] index.html にSIRIUSカード追加
+- [ ] rl/ に4ページ追加（最低限の内容 + ナビ）
+- [ ] リンク動作OK
+```
+
+```md
+TITLE: [SIRIUS][S-GP][P1] rl/spec.html に “動く仕様書” デモ（Bandit推奨）を追加
+LABELS: course:sirius, S-GP, priority:P1
+S_COLUMN: S-GP
+DEPENDS_ON: Issue01（+ Issue04/05 推奨）
+EST_SIZE: M
+A(S) COVERED: gp.03, env.ux.01
+
+## S（Spec）/ 仕様
+目的：
+- 既存の「Specで動くものを手に入れる」体験を、RLコースでも成立させる。
+- “学習の見える化” をブラウザ単体で提供する（ビルド不要）。
+
+デモ要件（Bandit推奨）：
+- 腕数Kと確率pをUIで設定
+- アルゴリズムを選べる（最低2種類以上：random/ε-greedy/UCB/TS など）
+- 実行すると cumulative reward / cumulative regret が見える（簡易チャート）
+
+受け入れ基準：
+- [ ] rl/spec.html をローカルで開くだけで動く（外部CDNなし）
+- [ ] UI操作→実行→結果が画面に出る
+- [ ] 上部ナビ（Scope/Index/Overview/Spec）と Home リンクがある
+- [ ] 動作が重くない（1回実行が短時間）
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたは rl/spec.html にブラウザデモを実装します。外部ライブラリ/CDNは禁止。静的HTML+JSのみ。
+
+手順：
+1) rl/spec.html を開き、既存サイトの雰囲気（ダーク/ネオン/カード）に馴染むUI領域を作る。
+2) Banditデモを実装する（推奨）：
+   - seedable RNG（例：mulberry32など）をJS内で実装
+   - Bernoulli bandit：K本の腕、p[i]で 0/1 報酬
+   - 方策：random と epsilon-greedy（最低2種類）。余裕があればUCB/Thompsonも追加。
+   - step数：既定 500（UIで変更可）
+3) 出力：
+   - cumulative reward
+   - cumulative regret（best_p - chosen_p の累積）
+   - 可能なら「どの腕を何回引いたか」のカウントも表示
+4) 描画は canvas か、divで簡易棒グラフでもOK（見やすさ優先）。
+5) 既存導線：
+   - 上部ナビ（Scope/Index/Overview/Spec）と Home リンクを必ず置く。
+6) ブラウザで動作確認：pを変えると結果が変わること。
+
+注意：
+- ページは軽量にする（ループは500〜2000程度）。
+- コードはページ内に完結（将来分離できるよう関数化はする）。
+~~~ 
+
+## Definition of Done
+- [ ] rl/spec.html に動くデモ
+- [ ] UI操作で結果が変わる
+- [ ] 導線OK
+```

--- a/backlog/S-OBS.md
+++ b/backlog/S-OBS.md
@@ -1,0 +1,64 @@
+# S-OBS（観測 / ログ / Goldilocks制御）
+
+```md
+TITLE: [SIRIUS][S-OBS][P1] 学習ログ/Outcomeから mastery(p) をベイズ更新し、次のガイドLv（Goldilocks帯）を提案する
+LABELS: course:sirius, S-OBS, priority:P1
+S_COLUMN: S-OBS
+DEPENDS_ON: Issue02（PRテンプレ）, Issue03（ログ基盤）
+EST_SIZE: M
+A(S) COVERED: obs.01, obs.02, gp.ops.01
+
+## S（Spec）/ 仕様
+目的：
+- PRテンプレの「所要時間・試行回数・Outcome」およびテスト結果を、次の課題/ガイドLv提案に使える形にする。
+- FAQで言及されている “pをベイズ更新して次のガイドLv提案（Goldilocks帯維持）” を、最小実装として提供する。
+
+仕様（最小）：
+- mastery推定：Beta分布（成功/失敗）で p を更新
+  - success=Pass、fail=Fail（まずは二値でOK）
+- Goldilocks帯（例）：
+  - p < 0.55 : 易しくする（ガイドLv↑ / 課題難度↓）
+  - 0.55 <= p <= 0.80 : 維持
+  - p > 0.80 : 難しくする（ガイドLv↓ / 課題難度↑）
+- 生成物：
+  - sirius_rl/obs/mastery.py（beta更新 + 推奨ガイドLv）
+  - scripts/suggest_next.py（入力JSONから提案を出すCLI）
+  - docs/rl/ops_goldilocks.md（運用説明）
+  - tests/test_mastery.py（計算の正しさ）
+
+受け入れ基準：
+- [ ] `python scripts/suggest_next.py --input <file>` が動き、ガイドLv提案が出る
+- [ ] Beta更新がテストで検証される
+- [ ] docsに「入力フォーマット（最低限）」が書かれている
+
+## H（How）/ Codex Prompt（実装指示）
+~~~text
+あなたは “Goldilocks帯維持” の最小実装を行います。GitHub APIは使わず、まずはローカル入力（JSON/JSONL）でOK。
+
+手順：
+1) sirius_rl/obs/mastery.py を追加：
+   - update_beta(alpha, beta, success: bool) -> (alpha, beta)
+   - mean_p(alpha,beta)
+   - recommend_guide_level(p, current_level, rules) -> next_level
+   - ルールは設定で変えられる形（定数でもOK）
+2) scripts/suggest_next.py を追加：
+   - 入力：JSONまたはJSONL
+     - 例：{"attempts":[{"outcome":"pass","time_min":35,"trials":2}, ...], "current_level":2}
+   - 出力：推定pと next_level（標準出力）
+3) docs/rl/ops_goldilocks.md を追加：
+   - 何を入力にするか（Outcome, time, trials）
+   - どう更新するか（Beta）
+   - Goldilocks帯の考え方
+4) tests/test_mastery.py：
+   - 小さな例で alpha/beta が期待通りに更新される
+   - pに応じて next_level が期待通りになる
+
+注意：
+- 最小実装なので、まずは pass/fail のみでOK。
+- 後で Issue09 の推薦ロジックに接続できるよう、APIは小さく整える。
+~~~ 
+
+## Definition of Done
+- [ ] mastery.py / suggest_next.py / ops_goldilocks.md / tests 追加
+- [ ] CI green
+```


### PR DESCRIPTION
## Summary
- add a backlog directory to store meeting outcomes grouped by S column
- document each SIRIUS issue in copy-paste ready markdown blocks for GitHub

## Testing
- Not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bdfff483083339b4ebc5ab68bdb56)