### PR TITLE
Add SIRIUS RL course navigation and bandit demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1003,6 +1003,7 @@
                 <li><span class="kbd">ALTAIR</span>：長期でじっくり鍛える</li>
                 <li><a href="ec/index.html"><span class="kbd">RIGEL</span>：Eカード（カイジ）で観点束Sとobligation A(S)を定義し、DTD（集合被覆）テスト生成まで動かす</a></li>
                 <li><a href="btd/overview.html"><span class="kbd">SPICA</span>：Beat Diffusionで“条件付き生成”をつくる（仕様→動くイメージ→設計→実装）</a></li>
+                <li><a href="rl/index.html"><span class="kbd">SIRIUS</span>：Bandit→MDP→Q-learning をGitHub運用で攻略するRLコース</a></li>
                 <li><span class="kbd">DENEB</span>：QR→CSVを型ファーストで作る（1週間）</li>
                 <li><a href="qr/samples.html"><span class="kbd">DENEB Samples</span>：テスト用サンプルQR（フォーマット別）</a></li>
                 <li>各コースは <span class="kbd">scope / index / overview / spec</span> へ（DENEBは <span class="kbd">index / overview / spec / samples</span>、SPICAは <span class="kbd">overview / spec / design / implement</span>、RIGELは <span class="kbd">scope / index / ecard_spec / spec</span>）</li>
@@ -1276,14 +1277,14 @@
           </article>
 
           <!-- SIRIUS -->
-          <article class="course" id="sirius" aria-label="コース SIRIUS">
+          <article class="course" id="sirius" aria-label="コース SIRIUS（強化学習）">
             <div class="courseHead">
               <div class="courseName">
                 <span class="tag hot"><span class="chip" aria-hidden="true"></span>NEW コース SIRIUS</span>
                 <h4>SIRIUS</h4>
                 <p>
-                  タロット占いを題材に、CLI / REST API / Web UI / 自動テストまで作るフルスタックコース。
-                  spread / seed再現 / 正逆位置の仕様を「動く仕様書」で即確認しながら進めます。
+                  Bandit → MDP → Q-learning を小さなステップで動かしながら進める強化学習コース。
+                  GitHub（Issue → PR → テスト採点）の運用で、Scope / Index / Overview / Spec を回す導線を揃えています。
                 </p>
               </div>
 
@@ -1294,7 +1295,7 @@
             </div>
 
             <div class="links" role="list">
-              <a class="linkCard" role="listitem" href="tu/overview.html">
+              <a class="linkCard" role="listitem" href="rl/scope.html">
                 <div class="ico" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="none">
                     <path d="M12 6v12M6 12h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -1302,12 +1303,12 @@
                   </svg>
                 </div>
                 <div class="t">
-                  <b>概要・アーキテクチャ</b>
-                  <small>tu/overview.html</small>
+                  <b>スコープ / 到達イメージ</b>
+                  <small>rl/scope.html</small>
                 </div>
               </a>
 
-              <a class="linkCard" role="listitem" href="tu/implement_spec.html">
+              <a class="linkCard" role="listitem" href="rl/index.html">
                 <div class="ico" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="none">
                     <path d="M7 7h10M7 12h10M7 17h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -1315,12 +1316,12 @@
                   </svg>
                 </div>
                 <div class="t">
-                  <b>実装仕様書</b>
-                  <small>tu/implement_spec.html</small>
+                  <b>学習手順 / GitHub運用</b>
+                  <small>rl/index.html</small>
                 </div>
               </a>
 
-              <a class="linkCard" role="listitem" href="tu/issues.html">
+              <a class="linkCard" role="listitem" href="rl/overview.html">
                 <div class="ico" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="none">
                     <path d="M7 6h10M7 10h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -1329,12 +1330,12 @@
                   </svg>
                 </div>
                 <div class="t">
-                  <b>GitHub Issue集</b>
-                  <small>tu/issues.html</small>
+                  <b>世界観 / Overview</b>
+                  <small>rl/overview.html</small>
                 </div>
               </a>
 
-              <a class="linkCard" role="listitem" href="tu/spec.html">
+              <a class="linkCard" role="listitem" href="rl/spec.html">
                 <div class="ico" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="none">
                     <path d="M8 12h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -1343,16 +1344,16 @@
                   </svg>
                 </div>
                 <div class="t">
-                  <b>動く仕様書</b>
-                  <small>tu/spec.html</small>
+                  <b>動く仕様書（Banditデモ）</b>
+                  <small>rl/spec.html</small>
                 </div>
               </a>
             </div>
 
             <div class="courseFoot">
               <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>提出フローを見る</a>
-              <a class="btn" href="tu/spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書を開く</a>
-              <a class="btn primary" href="tu/overview.html"><span class="dot" aria-hidden="true"></span>SIRIUSを開始</a>
+              <a class="btn" href="rl/spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書を開く</a>
+              <a class="btn primary" href="rl/index.html"><span class="dot" aria-hidden="true"></span>SIRIUSを開始</a>
             </div>
           </article>
 

--- a/rl/index.html
+++ b/rl/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>SIRIUS RL | Index</title>
+  <link rel="stylesheet" href="../course_dark.css" />
+  <link rel="stylesheet" href="rl-theme.css" />
+</head>
+<body class="rl-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS (RL) | Index</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUS (RL) ナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a href="scope.html">Scope</a>
+          <a class="active" href="index.html">Index</a>
+          <a href="overview.html">Overview</a>
+          <a href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>Banditデモ</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a href="scope.html">Scope</a>
+        <a class="active" href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>Banditデモ</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap rl-content">
+    <section class="rl-card rl-hero">
+      <p class="eyebrow">SIRIUS (Reinforcement Learning)</p>
+      <h1>Index / 進め方</h1>
+      <p class="lede">
+        GitHub運用（Issue → PR → テスト採点）で、Bandit → MDP → Q-learning を14日で攻略。
+        ここでは毎日の進め方と、提出物の粒度をまとめています。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>Banditデモへ</a>
+        <a class="btn" href="scope.html"><span class="dot" aria-hidden="true"></span>Scopeを確認</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="SIRIUS (RL) 内部ナビゲーション">
+        <a href="scope.html">Scope</a>
+        <a class="active" href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">GitHub運用（標準フロー）</div>
+      <ol>
+        <li><b>Issueを読む</b>：課題のScope/期待アウトプットを把握し、疑問はコメントで整理。</li>
+        <li><b>ブランチを切る</b>：小さなステップでPRを積み上げ、1PR=1テーマを意識。</li>
+        <li><b>テストを走らせる</b>：Banditデモはブラウザで、Q-learning以降はユニットテスト（任意）で観点を確認。</li>
+        <li><b>PRを出す</b>：試行回数・所要時間・得られた報酬/後悔の変化を簡潔に記録。</li>
+        <li><b>レビュー＆再挑戦</b>：フィードバックをIssueに反映し、seed付きで再現できる状態を保つ。</li>
+      </ol>
+      <div class="callout warn">Banditデモは seed / パラメータ付きで共有できるので、PR説明に実行条件を必ず残してください。</div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">14日ラフプラン</div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Day</th><th>テーマ</th><th>提出例</th></tr></thead>
+          <tbody>
+            <tr><td>1-2</td><td>Bandit UI確認・seed再現</td><td>p配列とアルゴリズム切替のスクショ/メモ</td></tr>
+            <tr><td>3-5</td><td>ε-greedy / UCB の比較</td><td>累積報酬/後悔の差分、選択回数の表</td></tr>
+            <tr><td>6-8</td><td>MDPミニ環境の設計</td><td>状態・行動・遷移表、報酬の考え方</td></tr>
+            <tr><td>9-11</td><td>Q-learning 素振り</td><td>更新式の確認、学習率/割引率の試行ログ</td></tr>
+            <tr><td>12-14</td><td>まとめとテスト観点整理</td><td>A(S)リストと再現手順、次の改善案</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">Mission（プレースホルダ）</div>
+      <div class="rl-grid">
+        <div class="stat">
+          <strong>Mission 01</strong>
+          <span>自分のp配列でBanditを回し、ε-greedyとrandomを比較。seedと結果をIssueに貼る。</span>
+        </div>
+        <div class="stat">
+          <strong>Mission 02</strong>
+          <span>MDPの状態遷移表を作り、報酬設計の意図を短く説明。PRで図や表を共有。</span>
+        </div>
+        <div class="stat">
+          <strong>Mission 03</strong>
+          <span>Q-learningの学習率・割引率を2パターン試し、エピソード報酬の推移をまとめる。</span>
+        </div>
+      </div>
+      <div class="callout good">ミッションはリポジトリのIssue化を想定。PRテンプレに「seed」「アルゴリズム」「ステップ数」を記録するだけで再現性が保てます。</div>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+</body>
+</html>

--- a/rl/overview.html
+++ b/rl/overview.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>SIRIUS RL | Overview</title>
+  <link rel="stylesheet" href="../course_dark.css" />
+  <link rel="stylesheet" href="rl-theme.css" />
+</head>
+<body class="rl-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS (RL) | Overview</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUS (RL) ナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a href="scope.html">Scope</a>
+          <a href="index.html">Index</a>
+          <a class="active" href="overview.html">Overview</a>
+          <a href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>Banditデモ</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a class="active" href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>Banditデモ</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap rl-content">
+    <section class="rl-card rl-hero">
+      <p class="eyebrow">SIRIUS (Reinforcement Learning)</p>
+      <h1>Overview / 世界観</h1>
+      <p class="lede">
+        「Scope → Index → Overview → Spec」の導線で、RL学習を航路化。
+        Overviewでは、システムの粒度・成果物・テスト観点を地図としてまとめます。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書へ</a>
+        <a class="btn" href="scope.html"><span class="dot" aria-hidden="true"></span>Scopeを確認</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="SIRIUS (RL) 内部ナビゲーション">
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a class="active" href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">航路（Scope→Index→Overview→Spec）</div>
+      <div class="rl-grid">
+        <div class="stat">
+          <strong>Scope</strong>
+          <span>Bandit/MDP/Q-learningの到達イメージと、観点束S・A(S)の素案。</span>
+        </div>
+        <div class="stat">
+          <strong>Index</strong>
+          <span>14日分の進め方、GitHub運用、PR粒度、seed共有の作法。</span>
+        </div>
+        <div class="stat">
+          <strong>Overview</strong>
+          <span>成果物の構造、学習ログの保存先、テスト観点の紐づけ。</span>
+        </div>
+        <div class="stat">
+          <strong>Spec</strong>
+          <span>ブラウザで動くBanditデモ。累積報酬/後悔・選択回数を即確認。</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">成果物の構造</div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>レイヤ</th><th>中身</th><th>証跡</th></tr></thead>
+          <tbody>
+            <tr><td>Spec</td><td>Banditデモ（HTML/JSのみ）</td><td>seedとp配列を記録したスクショ/メモ</td></tr>
+            <tr><td>Model</td><td>MDP定義（状態・行動・遷移・報酬）</td><td>テーブル or markdown図解、Issueリンク</td></tr>
+            <tr><td>Algorithm</td><td>Q-learning更新式とハイパーパラメータ</td><td>テスト観点 S/A(S) と紐づいたノート</td></tr>
+            <tr><td>Ops</td><td>GitHub運用（Issue→PR→テスト）</td><td>PRテンプレ、CIログ（任意）</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">テスト観点のヒント</div>
+      <ul>
+        <li>Bandit：探索率が指定どおり変化するか（seed固定で比較）。</li>
+        <li>MDP：終端状態の扱い（ループ有無）で価値計算が変わることを確認。</li>
+        <li>Q-learning：学習率/割引率/εが0〜1の範囲でクリップされているか。</li>
+        <li>再現性：seedとp配列がIssue/PRに残り、同じ曲線を描けるか。</li>
+      </ul>
+      <div class="callout good">ブラウザだけで完結するデモを土台に、バックエンドやPython実装を追加してもOK。まずはここで「動く仕様書」を手に入れてください。</div>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+</body>
+</html>

--- a/rl/rl-theme.css
+++ b/rl/rl-theme.css
@@ -1,0 +1,188 @@
+@import url("../bt30/altair-theme.css");
+
+:root {
+  color-scheme: dark;
+}
+
+body.rl-page {
+  margin: 0;
+  font-family: "Inter", "Hiragino Sans", "Noto Sans JP", system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 700px at 70% 10%, rgba(167, 139, 250, 0.2), transparent 55%),
+    radial-gradient(900px 560px at 20% 25%, rgba(124, 247, 255, 0.16), transparent 55%),
+    radial-gradient(760px 560px at 80% 60%, rgba(255, 94, 168, 0.1), transparent 60%),
+    linear-gradient(180deg, var(--bg0), var(--bg1) 45%, var(--bg2));
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+}
+
+.wrap {
+  position: relative;
+  z-index: 2;
+  width: min(var(--max), calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.skip {
+  position: absolute;
+  left: -999px;
+  top: 14px;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.82);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  z-index: 9999;
+}
+
+.skip:focus {
+  left: 16px;
+}
+
+.navlinks a.active {
+  color: var(--text);
+  border-color: rgba(124, 247, 255, 0.32);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 0 3px rgba(124, 247, 255, 0.18) inset;
+}
+
+.rl-page .rl-content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 12px auto 24px;
+}
+
+.rl-hero {
+  margin: 16px 0 6px;
+  display: grid;
+  gap: 14px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.lede {
+  margin: 10px 0 0;
+  color: var(--muted);
+  line-height: 1.8;
+  max-width: 80ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.subnav {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.subnav a {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.subnav a.active {
+  color: var(--text);
+  border-color: rgba(124, 247, 255, 0.32);
+  box-shadow: 0 0 0 3px rgba(124, 247, 255, 0.16) inset;
+}
+
+.rl-card {
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.rl-card::before {
+  content: "";
+  position: absolute;
+  inset: -80px;
+  background:
+    radial-gradient(420px 180px at 20% 20%, rgba(124, 247, 255, 0.1), transparent 60%),
+    radial-gradient(420px 160px at 80% 70%, rgba(167, 139, 250, 0.09), transparent 62%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.rl-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.rl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.rl-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.callout {
+  border-left: 4px solid var(--accent);
+  padding: 12px 14px;
+  background: rgba(124, 247, 255, 0.08);
+  border-radius: 12px;
+  color: var(--muted);
+}
+
+.callout.warn { border-left-color: var(--gold); background: rgba(255, 211, 110, 0.1); }
+.callout.good { border-left-color: #63f2a1; background: rgba(99, 242, 161, 0.12); }
+
+.stat-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.stat {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.24);
+  border-radius: 14px;
+  padding: 12px;
+}
+
+.stat strong { display: block; margin-bottom: 4px; color: var(--text); }
+.stat span { color: var(--muted); }
+
+.table-wrap { overflow-x: auto; }
+
+@media (max-width: 960px) {
+  .header .nav { justify-content: flex-start; }
+}

--- a/rl/scope.html
+++ b/rl/scope.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>SIRIUS RL | Scope</title>
+  <link rel="stylesheet" href="../course_dark.css" />
+  <link rel="stylesheet" href="rl-theme.css" />
+</head>
+<body class="rl-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS (RL) | Scope</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUS (RL) ナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a class="active" href="scope.html">Scope</a>
+          <a href="index.html">Index</a>
+          <a href="overview.html">Overview</a>
+          <a href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a class="active" href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>Banditデモ</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap rl-content">
+    <section class="rl-card rl-hero">
+      <p class="eyebrow">SIRIUS (Reinforcement Learning)</p>
+      <h1>Scope / 到達イメージ</h1>
+      <p class="lede">
+        Bandit → MDP → Q-learning を 14日プランで動かしながら、RLの基本とGitHub運用を重ねて体験するコース。
+        Scopeでは「どこまで作るか」と「動く姿」を最短で共有します。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="index.html"><span class="dot" aria-hidden="true"></span>Indexへ</a>
+        <a class="btn" href="spec.html"><span class="dot" aria-hidden="true"></span>Banditデモを開く</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="SIRIUS (RL) 内部ナビゲーション">
+        <a class="active" href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">ゴールと制約</div>
+      <div class="stat-list">
+        <div class="stat"><strong>期間の目安</strong><span>1日1時間 × 14日</span></div>
+        <div class="stat"><strong>環境</strong><span>ブラウザでデモ確認（外部CDNなし） / GitHubでPR提出</span></div>
+        <div class="stat"><strong>観点</strong><span>探索・活用のバランス、状態遷移、価値推定</span></div>
+        <div class="stat"><strong>出口</strong><span>Bandit可視化 → MDP設計 → Q-learningプロトタイプ</span></div>
+      </div>
+      <div class="callout">
+        「動く仕様書」で腕ごとの報酬・後悔を可視化し、Issue / PR / テストで学習ログを残す前提です。
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">到達する「動く姿」</div>
+      <ul>
+        <li>Bandit（K腕・p[i]可変）をブラウザで操作し、アルゴリズム別の報酬/後悔/選択回数を確認できる。</li>
+        <li>MDPの小さな例（状態・行動・遷移・報酬）が文章で定義され、Issueに落とし込める。</li>
+        <li>Q-learningの更新式とハイパーパラメータが、テスト観点（S, A(S)）と紐づいた形で説明される。</li>
+        <li>GitHub運用：Issueで課題提示 → PRで提出 → テストで採点、を想定した導線が全ページに存在。</li>
+      </ul>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">Scope（範囲）</div>
+      <div class="rl-grid">
+        <div>
+          <h3>Bandit</h3>
+          <p class="lede">K腕・p[i]入力・seed再現・ランダム / ε-greedy / UCB の切替。</p>
+          <ul>
+            <li>累積報酬・累積後悔のプロット</li>
+            <li>腕ごとの選択回数と推定値を表示</li>
+            <li>シード入力でGitHub上の議論を再現</li>
+          </ul>
+        </div>
+        <div>
+          <h3>MDP</h3>
+          <p class="lede">状態・行動・遷移確率の最小サンプルを提示し、価値の更新を文章で整備。</p>
+          <ul>
+            <li>4〜6状態のミニ環境を想定</li>
+            <li>報酬設計とエピソードの流れを表で整理</li>
+            <li>後続のQ-learning課題への橋渡し</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Q-learning</h3>
+          <p class="lede">更新式、学習率、割引率、εスケジュールの説明を、テスト観点と紐づける。</p>
+          <ul>
+            <li>状態-行動価値表の例と初期化方針</li>
+            <li>エピソード数・探索率の推奨レンジ</li>
+            <li>「正しく減衰しているか」をチェックするテスト観点</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">観点束 S と A(S)</div>
+      <p>このコースで観測する軸（S）と離散条件（A(S)）の素案：</p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>観点 S</th><th>例</th><th>A(S)（離散条件）</th></tr></thead>
+          <tbody>
+            <tr><td>探索率</td><td>ε の変化パターン</td><td>固定 / ステップ減衰 / エピソード減衰</td></tr>
+            <tr><td>価値推定</td><td>初期値 / 更新式</td><td>楽観初期化 / ゼロ初期化 / 逐次平均</td></tr>
+            <tr><td>報酬設計</td><td>+1 / 0 / -1 の付け方</td><td>成功時のみ +1 / 失敗で -1 / 遷移コスト型</td></tr>
+            <tr><td>状態遷移</td><td>終端の扱い</td><td>終端即終了 / ペナルティ付与 / ループ許可</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+</body>
+</html>

--- a/rl/spec.html
+++ b/rl/spec.html
@@ -1,0 +1,384 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>SIRIUS RL | Spec（Banditデモ）</title>
+  <link rel="stylesheet" href="../course_dark.css" />
+  <link rel="stylesheet" href="rl-theme.css" />
+  <style>
+    .demo-grid {
+      display: grid;
+      grid-template-columns: 1.05fr 0.95fr;
+      gap: 14px;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 10px;
+    }
+
+    label span { display: block; margin-bottom: 6px; color: var(--muted); font-size: 13px; }
+    input, select, textarea {
+      width: 100%;
+      padding: 10px;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      background: rgba(0, 0, 0, 0.25);
+      color: var(--text);
+      font-size: 14px;
+    }
+    textarea { min-height: 92px; resize: vertical; }
+
+    .chart-card { background: rgba(0,0,0,0.24); border:1px solid rgba(255,255,255,0.12); border-radius: 16px; padding: 12px; }
+    #chart { width: 100%; height: 260px; display: block; }
+
+    .counts { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+    .count-row { display: grid; grid-template-columns: 80px 1fr auto auto; align-items: center; gap: 10px; }
+    .count-bar { height: 10px; background: rgba(124,247,255,0.28); border-radius: 999px; position: relative; overflow: hidden; }
+    .count-bar span { position: absolute; inset: 0; background: linear-gradient(90deg, rgba(124,247,255,0.32), rgba(167,139,250,0.26)); }
+    .count-meta { color: var(--muted); font-size: 12px; }
+
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; margin-top: 10px; }
+    .metric { border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; padding: 12px; background: rgba(0,0,0,0.24); }
+    .metric b { display: block; margin-bottom: 6px; color: var(--text); }
+
+    @media (max-width: 960px) {
+      .demo-grid { grid-template-columns: 1fr; }
+      .count-row { grid-template-columns: 70px 1fr auto; }
+    }
+  </style>
+</head>
+<body class="rl-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>SIRIUS (RL) | Spec</p>
+        </div>
+      </div>
+
+      <nav aria-label="SIRIUS (RL) ナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a href="scope.html">Scope</a>
+          <a href="index.html">Index</a>
+          <a href="overview.html">Overview</a>
+          <a class="active" href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="#demo"><span class="dot" aria-hidden="true"></span>デモを実行</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a class="active" href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="#demo"><span class="dot" aria-hidden="true"></span>デモを実行</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap rl-content">
+    <section class="rl-card rl-hero">
+      <p class="eyebrow">SIRIUS (Reinforcement Learning)</p>
+      <h1>Spec / Banditデモ</h1>
+      <p class="lede">
+        外部ライブラリなしのブラウザデモ。腕数 K と p を指定し、アルゴリズム（random / ε-greedy / UCB）を切り替えて報酬と後悔を確認できます。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="#demo"><span class="dot" aria-hidden="true"></span>パラメータを設定</a>
+        <a class="btn" href="overview.html"><span class="dot" aria-hidden="true"></span>Overviewへ戻る</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="SIRIUS (RL) 内部ナビゲーション">
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a class="active" href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="rl-card rl-stack" id="demo">
+      <div class="badge">パラメータを設定して実行</div>
+      <div class="demo-grid">
+        <form id="banditForm" class="rl-stack">
+          <div class="form-grid">
+            <label>
+              <span>腕の本数 K</span>
+              <input type="number" name="arms" min="2" value="4" />
+            </label>
+            <label>
+              <span>試行ステップ数</span>
+              <input type="number" name="steps" min="10" value="500" />
+            </label>
+            <label>
+              <span>アルゴリズム</span>
+              <select name="algo">
+                <option value="random">random</option>
+                <option value="epsilon">ε-greedy</option>
+                <option value="ucb">UCB1</option>
+              </select>
+            </label>
+            <label>
+              <span>ε（ε-greedy）</span>
+              <input type="number" name="epsilon" step="0.01" min="0" max="1" value="0.10" />
+            </label>
+            <label>
+              <span>探索係数 c（UCB）</span>
+              <input type="number" name="ucbC" step="0.1" min="0" value="1.2" />
+            </label>
+            <label>
+              <span>seed（任意の文字列）</span>
+              <input type="text" name="seed" value="sirius" />
+            </label>
+          </div>
+          <label>
+            <span>各腕の成功確率 p[i]（カンマ / 改行区切り）</span>
+            <textarea name="probs">0.15, 0.35, 0.55, 0.75</textarea>
+          </label>
+          <div class="hero-actions">
+            <button class="btn primary" type="submit"><span class="dot" aria-hidden="true"></span>実行</button>
+            <button class="btn" type="button" id="fillSamples"><span class="dot" aria-hidden="true"></span>サンプル値をセット</button>
+          </div>
+        </form>
+
+        <div class="rl-stack">
+          <div class="metrics">
+            <div class="metric"><b>累積報酬</b><span id="rewardTotal">-</span></div>
+            <div class="metric"><b>累積後悔</b><span id="regretTotal">-</span></div>
+            <div class="metric"><b>ベスト腕のp*</b><span id="bestP">-</span></div>
+            <div class="metric"><b>ステップ数</b><span id="stepCount">-</span></div>
+          </div>
+          <div class="chart-card">
+            <canvas id="chart" aria-label="累積報酬と後悔の推移"></canvas>
+          </div>
+          <div>
+            <h3 style="margin-bottom:6px;">腕ごとの選択回数</h3>
+            <div id="counts" class="counts" aria-live="polite"></div>
+          </div>
+        </div>
+      </div>
+      <div class="callout">結果とパラメータはGitHubのIssue/PRに貼り付けて、同じ seed と p を指定すれば再現できます。</div>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+  <script>
+    (() => {
+      const form = document.getElementById('banditForm');
+      const rewardTotal = document.getElementById('rewardTotal');
+      const regretTotal = document.getElementById('regretTotal');
+      const bestP = document.getElementById('bestP');
+      const stepCount = document.getElementById('stepCount');
+      const countsEl = document.getElementById('counts');
+      const chart = document.getElementById('chart');
+      const fillSamples = document.getElementById('fillSamples');
+      let lastRewards = [0];
+      let lastRegrets = [0];
+
+      const clamp = (v, min, max) => Math.min(Math.max(v, min), max);
+
+      const hashSeed = (str) => {
+        let h = 1779033703 ^ str.length;
+        for (let i = 0; i < str.length; i++) {
+          h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+          h = (h << 13) | (h >>> 19);
+        }
+        return () => {
+          h = Math.imul(h ^ (h >>> 16), 2246822507);
+          h = Math.imul(h ^ (h >>> 13), 3266489909);
+          h ^= h >>> 16;
+          return h >>> 0;
+        };
+      };
+
+      const mulberry32 = (a) => {
+        return () => {
+          a |= 0;
+          a = (a + 0x6d2b79f5) | 0;
+          let t = Math.imul(a ^ (a >>> 15), 1 | a);
+          t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+          return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+        };
+      };
+
+      const makeRng = (seed) => mulberry32(hashSeed(seed || 'sirius')());
+
+      const parseProbabilities = (value, k) => {
+        const raw = value
+          .split(/[\,\n\s]+/)
+          .map((v) => v.trim())
+          .filter(Boolean)
+          .map((n) => clamp(parseFloat(n), 0, 1))
+          .filter((n) => !Number.isNaN(n));
+        if (raw.length === 0) {
+          raw.push(0.2, 0.4, 0.6);
+        }
+        const base = raw.length;
+        const probs = [];
+        for (let i = 0; i < k; i++) {
+          const src = raw[i % base];
+          probs.push(typeof src === 'number' ? src : Math.max(0.05, Math.min(0.9, (i + 1) / (k + 2))));
+        }
+        return probs;
+      };
+
+
+      const drawChart = (rewards, regrets) => {
+        const ctx = chart.getContext('2d');
+        const width = chart.clientWidth || 640;
+        const height = 260;
+        const dpr = Math.min(2, window.devicePixelRatio || 1);
+        chart.width = width * dpr;
+        chart.height = height * dpr;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        ctx.clearRect(0, 0, width, height);
+
+        const maxVal = Math.max(1, ...rewards, ...regrets);
+        const step = rewards.length > 1 ? width / (rewards.length - 1) : width;
+
+        ctx.strokeStyle = 'rgba(255,255,255,0.16)';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(0, height - 20);
+        ctx.lineTo(width, height - 20);
+        ctx.stroke();
+
+        const drawLine = (data, color) => {
+          ctx.strokeStyle = color;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          data.forEach((v, i) => {
+            const x = i * step;
+            const y = height - 20 - (v / maxVal) * (height - 40);
+            if (i === 0) ctx.moveTo(x, y);
+            else ctx.lineTo(x, y);
+          });
+          ctx.stroke();
+        };
+
+        drawLine(rewards, 'rgba(124,247,255,0.9)');
+        drawLine(regrets, 'rgba(255,94,168,0.9)');
+      };
+
+      const renderCounts = (counts, probs) => {
+        const max = Math.max(1, ...counts);
+        countsEl.innerHTML = counts
+          .map((c, i) => {
+            const width = (c / max) * 100;
+            return `
+              <div class="count-row">
+                <div class="count-meta">Arm ${i + 1}</div>
+                <div class="count-bar" aria-hidden="true"><span style="width:${width}%"></span></div>
+                <div class="count-meta">${c} 回</div>
+                <div class="count-meta">p=${probs[i].toFixed(2)}</div>
+              </div>
+            `;
+          })
+          .join('');
+      };
+
+      const simulate = (event) => {
+        event?.preventDefault();
+        const k = Math.max(2, parseInt(form.elements.arms.value, 10) || 2);
+        const steps = Math.max(10, parseInt(form.elements.steps.value, 10) || 100);
+        const epsilon = clamp(parseFloat(form.elements.epsilon.value) || 0, 0, 1);
+        const algo = form.elements.algo.value;
+        const ucbC = Math.max(0, parseFloat(form.elements.ucbC.value) || 1.2);
+        const probs = parseProbabilities(form.elements.probs.value, k);
+        const best = Math.max(...probs);
+        const rng = makeRng(form.elements.seed.value || 'sirius');
+
+        const counts = Array.from({ length: k }, () => 0);
+        const q = Array.from({ length: k }, () => 0);
+        let totalReward = 0;
+        let totalRegret = 0;
+        const rewardHistory = [];
+        const regretHistory = [];
+
+        const pickArgmax = (arr) => {
+          let idx = 0;
+          let val = -Infinity;
+          for (let i = 0; i < arr.length; i++) {
+            if (arr[i] > val) {
+              val = arr[i];
+              idx = i;
+            }
+          }
+          return idx;
+        };
+
+        for (let step = 0; step < steps; step++) {
+          let arm = 0;
+          if (algo === 'random') {
+            arm = Math.floor(rng() * k);
+          } else if (algo === 'epsilon') {
+            if (rng() < epsilon) arm = Math.floor(rng() * k);
+            else arm = pickArgmax(q);
+          } else {
+            // UCB1
+            const untried = counts.findIndex((c) => c === 0);
+            if (untried !== -1) arm = untried;
+            else {
+              const total = step + k;
+              const scores = q.map((mean, i) => mean + ucbC * Math.sqrt(Math.log(total) / counts[i]));
+              arm = pickArgmax(scores);
+            }
+          }
+
+          const reward = rng() < probs[arm] ? 1 : 0;
+          counts[arm] += 1;
+          const n = counts[arm];
+          q[arm] += (reward - q[arm]) / n;
+          totalReward += reward;
+          totalRegret += best - probs[arm];
+          rewardHistory.push(totalReward);
+          regretHistory.push(totalRegret);
+        }
+
+        rewardTotal.textContent = totalReward.toFixed(2);
+        regretTotal.textContent = totalRegret.toFixed(2);
+        bestP.textContent = best.toFixed(3);
+        stepCount.textContent = steps;
+        renderCounts(counts, probs);
+        lastRewards = rewardHistory;
+        lastRegrets = regretHistory;
+        drawChart(lastRewards, lastRegrets);
+      };
+
+      fillSamples?.addEventListener('click', () => {
+        form.elements.probs.value = '0.05, 0.12, 0.4, 0.65, 0.82';
+        form.elements.arms.value = 5;
+        form.elements.steps.value = 800;
+        form.elements.epsilon.value = 0.08;
+        form.elements.algo.value = 'epsilon';
+        simulate();
+      });
+
+      form?.addEventListener('submit', simulate);
+      window.addEventListener('resize', () => drawChart(lastRewards, lastRegrets));
+      simulate();
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the SIRIUS reinforcement learning course card and shortcut on the home page pointing to rl/ pages
- create shared RL styling plus scope/index/overview pages with consistent navigation back to Home
- build a local Bandit demo on rl/spec.html with random/epsilon/UCB options, charting, and seedable inputs

## Testing
- Not run (static HTML updates)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be1dbd27c8333a05276cb4e4e256f)