### PR TITLE
Add RL core env, bandit, and gridworld foundations

### DIFF
--- a/docs/rl/G_W_E_S_A.md
+++ b/docs/rl/G_W_E_S_A.md
@@ -80,3 +80,11 @@
 - PR本文では docs/rl/PR_GATE.md のテンプレを用い、A_j に上記IDを列挙してください。
 - seed・CI時間・ログスキーマは “E（制約）” を守る形で調整します。
 - W/E/S/A(S) への追加・変更は新しいIssueでレビューし、ここに追記します。
+
+## 実装メモ（Python基盤）
+- `sirius_rl/env/base.py` に Envインターフェース（`reset(seed)`/`step(action)`）と `StepResult` を定義。
+- `sirius_rl/utils/seed.py` の `create_rng` で乱数生成器を統一（標準ライブラリのみ）。
+- `sirius_rl/utils/logging.py` の `JsonlLogger` は `{run_id, seed, t, episode, reward, info}` を固定スキーマでJSONL出力。
+- `sirius_rl/eval/runner.py` は方策と環境を与えて複数エピソードを回し、平均報酬や後悔（regret）を計算。
+- `sirius_rl/env/bandit.py` で Bernoulli Bandit、`sirius_rl/eval/regret.py` で期待後悔を算出。
+- `sirius_rl/env/gridworld.py` と `sirius_rl/algorithms/dp.py` で GridWorld + Value/Policy Iteration を提供。

--- a/rl/overview.html
+++ b/rl/overview.html
@@ -123,6 +123,37 @@
       </ul>
       <div class="callout good">ブラウザだけで完結するデモを土台に、バックエンドやPython実装を追加してもOK。まずはここで「動く仕様書」を手に入れてください。</div>
     </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">Python基盤</div>
+      <p>Issue03 以降で追加される Python 実装の骨格は <code>sirius_rl/</code> パッケージに集約しました。</p>
+      <ul>
+        <li><code>sirius_rl/env/base.py</code> に Env プロトコル（<code>reset(seed)</code>, <code>step(action)</code>）と <code>StepResult</code> を定義。</li>
+        <li><code>sirius_rl/utils/seed.py</code> で RNG を統一、<code>sirius_rl/utils/logging.py</code> で JSONL ログ（<code>run_id/seed/t/episode/reward/info</code>）。</li>
+        <li><code>sirius_rl/eval/runner.py</code> がエピソード評価と平均報酬/後悔計算を担当。</li>
+      </ul>
+      <div class="callout info">seed を固定すれば同じ評価結果・ログが得られ、CI での再現性が確保されます。</div>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">Bandit (環境/後悔)</div>
+      <p><code>sirius_rl/env/bandit.py</code> では Bernoulli Bandit を実装し、<code>sirius_rl/eval/regret.py</code> で期待後悔を算出します。</p>
+      <ul>
+        <li>アクションは腕の番号（0..K-1）、報酬は {0,1} のベルヌーイ。</li>
+        <li>同一 seed なら報酬系列と評価結果が一致。</li>
+        <li>ベースライン方策（例: 一様ランダム）も <code>evaluate_policy</code> で簡単に評価可能。</li>
+      </ul>
+    </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">GridWorld &amp; DP</div>
+      <p>状態を持つ MDP 例として GridWorld を <code>sirius_rl/env/gridworld.py</code> に実装。Value/Policy Iteration は <code>sirius_rl/algorithms/dp.py</code>。</p>
+      <ul>
+        <li>行動は上下左右（0..3）。壁や終端状態を含むグリッドを <code>model()</code> でテーブル化。</li>
+        <li>step_penalty・終端報酬を使って最短経路に近い方策が得られる。</li>
+        <li>テストは小規模グリッドで高速に実行できるよう設計。</li>
+      </ul>
+    </section>
   </main>
 
   <script src="../bt30/altair_shared.js"></script>

--- a/sirius_rl/__init__.py
+++ b/sirius_rl/__init__.py
@@ -1,0 +1,8 @@
+"""Sirius RL foundational utilities and environments."""
+
+__all__ = [
+    "env",
+    "utils",
+    "eval",
+    "algorithms",
+]

--- a/sirius_rl/algorithms/__init__.py
+++ b/sirius_rl/algorithms/__init__.py
@@ -1,0 +1,8 @@
+"""Algorithms for Sirius RL."""
+
+from .dp import value_iteration, policy_iteration
+
+__all__ = [
+    "value_iteration",
+    "policy_iteration",
+]

--- a/sirius_rl/algorithms/dp.py
+++ b/sirius_rl/algorithms/dp.py
@@ -1,0 +1,104 @@
+"""Dynamic programming algorithms for tabular MDPs."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from sirius_rl.env.gridworld import GridWorldEnv, Transition
+
+
+def value_iteration(
+    env: GridWorldEnv,
+    gamma: float,
+    theta: float = 1e-6,
+) -> Tuple[List[float], List[int]]:
+    """Run value iteration returning value function and greedy policy."""
+
+    V = [0.0 for _ in range(env.n_states)]
+    model = env.model()
+
+    while True:
+        delta = 0.0
+        for s in range(env.n_states):
+            if s in env.terminal_states:
+                continue
+            v = V[s]
+            q_values = []
+            for a in range(env.n_actions):
+                transitions = model[s][a]
+                q = sum(
+                    t.probability * (t.reward + gamma * V[t.next_state])
+                    for t in transitions
+                )
+                q_values.append(q)
+            V[s] = max(q_values)
+            delta = max(delta, abs(v - V[s]))
+        if delta < theta:
+            break
+
+    policy: List[int] = []
+    for s in range(env.n_states):
+        if s in env.terminal_states:
+            policy.append(0)
+            continue
+        q_values = []
+        for a in range(env.n_actions):
+            transitions = model[s][a]
+            q = sum(
+                t.probability * (t.reward + gamma * V[t.next_state])
+                for t in transitions
+            )
+            q_values.append(q)
+        policy.append(int(max(range(len(q_values)), key=q_values.__getitem__)))
+
+    return V, policy
+
+
+def _policy_evaluation(env: GridWorldEnv, policy: List[int], gamma: float, theta: float) -> List[float]:
+    model = env.model()
+    V = [0.0 for _ in range(env.n_states)]
+    while True:
+        delta = 0.0
+        for s in range(env.n_states):
+            if s in env.terminal_states:
+                continue
+            v = V[s]
+            action = policy[s]
+            transitions: List[Transition] = model[s][action]
+            V[s] = sum(
+                t.probability * (t.reward + gamma * V[t.next_state])
+                for t in transitions
+            )
+            delta = max(delta, abs(v - V[s]))
+        if delta < theta:
+            break
+    return V
+
+
+def policy_iteration(env: GridWorldEnv, gamma: float, theta: float = 1e-6) -> Tuple[List[float], List[int]]:
+    """Iterative policy evaluation and improvement."""
+
+    policy = [0 for _ in range(env.n_states)]
+    model = env.model()
+
+    while True:
+        V = _policy_evaluation(env, policy, gamma, theta)
+        policy_stable = True
+        for s in range(env.n_states):
+            if s in env.terminal_states:
+                continue
+            old_action = policy[s]
+            action_values = []
+            for a in range(env.n_actions):
+                transitions = model[s][a]
+                q = sum(
+                    t.probability * (t.reward + gamma * V[t.next_state])
+                    for t in transitions
+                )
+                action_values.append(q)
+            best_action = int(max(range(len(action_values)), key=action_values.__getitem__))
+            policy[s] = best_action
+            if best_action != old_action:
+                policy_stable = False
+        if policy_stable:
+            return V, policy

--- a/sirius_rl/env/__init__.py
+++ b/sirius_rl/env/__init__.py
@@ -1,0 +1,13 @@
+"""Environments for Sirius RL exercises."""
+
+from .base import Environment, StepResult, BaseEnv
+from .bandit import BernoulliBanditEnv
+from .gridworld import GridWorldEnv
+
+__all__ = [
+    "Environment",
+    "StepResult",
+    "BaseEnv",
+    "BernoulliBanditEnv",
+    "GridWorldEnv",
+]

--- a/sirius_rl/env/bandit.py
+++ b/sirius_rl/env/bandit.py
@@ -1,0 +1,58 @@
+"""Bandit environment implementation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from sirius_rl.env.base import BaseEnv, StepResult
+from sirius_rl.eval import regret
+
+
+class BernoulliBanditEnv(BaseEnv):
+    """Simple Bernoulli multi-armed bandit environment."""
+
+    def __init__(self, probs: Sequence[float], seed: Optional[int] = None) -> None:
+        if not probs:
+            raise ValueError("probs must be non-empty")
+        self._probs: List[float] = [float(p) for p in probs]
+        for p in self._probs:
+            if p < 0.0 or p > 1.0:
+                raise ValueError("probabilities must be in [0, 1]")
+        super().__init__(seed=seed)
+
+    def reset(self, seed: Optional[int] = None) -> None:
+        if seed is not None:
+            self.reseed(seed)
+        return None
+
+    def step(self, action: int) -> StepResult:
+        if action < 0 or action >= len(self._probs):
+            raise ValueError("action out of bounds")
+
+        p = self._probs[action]
+        reward = float(self.rng.random() < p)
+        info: Dict[str, Any] = {"action": action, "p": p}
+        return StepResult(observation=None, reward=reward, terminated=False, info=info)
+
+    @property
+    def probs(self) -> List[float]:
+        return list(self._probs)
+
+    @property
+    def action_space(self) -> range:
+        return range(len(self._probs))
+
+    def regret_function(self):
+        """Return a regret function bound to this environment."""
+
+        def _regret(action: int) -> float:
+            return regret.expected_regret(self._probs, action)
+
+        return _regret
+
+    def rollout(self, actions: Iterable[int]) -> List[float]:
+        rewards: List[float] = []
+        for action in actions:
+            result = self.step(action)
+            rewards.append(result.reward)
+        return rewards

--- a/sirius_rl/env/base.py
+++ b/sirius_rl/env/base.py
@@ -1,0 +1,53 @@
+"""Core environment interfaces and helpers for RL tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+from sirius_rl.utils.seed import create_rng
+
+
+@dataclass
+class StepResult:
+    """Result container returned by environment steps."""
+
+    observation: Any
+    reward: float
+    terminated: bool
+    info: Dict[str, Any]
+
+
+@runtime_checkable
+class Environment(Protocol):
+    """Minimal environment protocol used across Sirius RL tasks."""
+
+    def reset(self, seed: Optional[int] = None) -> Any:
+        """Reset the environment.
+
+        Parameters
+        ----------
+        seed:
+            Optional seed for deterministic resets.
+        """
+
+    def step(self, action: Any) -> StepResult:
+        """Advance one step in the environment."""
+
+
+class BaseEnv:
+    """Base class that offers RNG management for derived environments."""
+
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self._seed: Optional[int] = seed
+        self.rng = create_rng(seed)
+
+    def reseed(self, seed: Optional[int]) -> None:
+        """Recreate the RNG with the provided seed."""
+
+        self._seed = seed
+        self.rng = create_rng(seed)
+
+    @property
+    def seed(self) -> Optional[int]:
+        return self._seed

--- a/sirius_rl/env/gridworld.py
+++ b/sirius_rl/env/gridworld.py
@@ -1,0 +1,141 @@
+"""Deterministic GridWorld environment for DP exercises."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from sirius_rl.env.base import BaseEnv, StepResult
+
+Action = int
+State = int
+
+
+def _state_id(x: int, y: int, width: int) -> State:
+    return y * width + x
+
+
+def _coords(state: State, width: int) -> Tuple[int, int]:
+    return state % width, state // width
+
+
+@dataclass
+class Transition:
+    probability: float
+    next_state: State
+    reward: float
+    terminated: bool
+
+
+class GridWorldEnv(BaseEnv):
+    """Tabular GridWorld with deterministic transitions."""
+
+    ACTIONS: Sequence[Tuple[int, int]] = ((0, -1), (1, 0), (0, 1), (-1, 0))
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        *,
+        walls: Optional[Iterable[Tuple[int, int]]] = None,
+        start: Tuple[int, int] = (0, 0),
+        terminals: Optional[Iterable[Tuple[int, int]]] = None,
+        reward_map: Optional[Dict[Tuple[int, int], float]] = None,
+        step_penalty: float = 0.0,
+        seed: Optional[int] = None,
+    ) -> None:
+        super().__init__(seed=seed)
+        self.width = width
+        self.height = height
+        self.start = start
+        self.step_penalty = step_penalty
+        self._walls = {
+            _state_id(x, y, self.width)
+            for (x, y) in walls
+        } if walls else set()
+        self._terminals = {
+            _state_id(x, y, self.width)
+            for (x, y) in terminals
+        } if terminals else set()
+        self._reward_map = {
+            _state_id(x, y, self.width): reward
+            for (x, y), reward in (reward_map or {}).items()
+        }
+        self._state: State = _state_id(*start, self.width)
+
+    @property
+    def state(self) -> State:
+        return self._state
+
+    @property
+    def terminal_states(self) -> List[State]:
+        return list(self._terminals)
+
+    @property
+    def walls(self) -> List[State]:
+        return list(self._walls)
+
+    @property
+    def n_states(self) -> int:
+        return self.width * self.height
+
+    @property
+    def n_actions(self) -> int:
+        return len(self.ACTIONS)
+
+    def _in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def reset(self, seed: Optional[int] = None) -> State:
+        if seed is not None:
+            self.reseed(seed)
+        self._state = _state_id(*self.start, self.width)
+        return self._state
+
+    def _next_state(self, action: Action) -> State:
+        if action < 0 or action >= self.n_actions:
+            raise ValueError("action out of bounds")
+
+        dx, dy = self.ACTIONS[action]
+        x, y = _coords(self._state, self.width)
+        nx, ny = x + dx, y + dy
+        candidate = _state_id(nx, ny, self.width) if self._in_bounds(nx, ny) else self._state
+        if candidate in self._walls:
+            return self._state
+        return candidate
+
+    def step(self, action: Action) -> StepResult:
+        next_state = self._next_state(action)
+        terminated = next_state in self._terminals
+        reward = self._reward_map.get(next_state, 0.0) + self.step_penalty
+        self._state = next_state
+        info = {"state": self._state}
+        return StepResult(
+            observation=self._state,
+            reward=reward,
+            terminated=terminated,
+            info=info,
+        )
+
+    def model(self) -> Dict[State, Dict[Action, List[Transition]]]:
+        """Return full transition model for DP algorithms."""
+
+        model: Dict[State, Dict[Action, List[Transition]]] = {}
+        original_state = self._state
+        for state in range(self.n_states):
+            self._state = state
+            model[state] = {}
+            for action in range(self.n_actions):
+                next_state = self._next_state(action)
+                terminated = next_state in self._terminals
+                reward = self._reward_map.get(next_state, 0.0) + self.step_penalty
+                model[state][action] = [
+                    Transition(
+                        probability=1.0,
+                        next_state=next_state,
+                        reward=reward,
+                        terminated=terminated,
+                    )
+                ]
+        self._state = original_state
+        return model

--- a/sirius_rl/eval/__init__.py
+++ b/sirius_rl/eval/__init__.py
@@ -1,0 +1,10 @@
+"""Evaluation utilities for Sirius RL."""
+
+from .runner import evaluate_policy
+from .regret import expected_regret, cumulative_regret
+
+__all__ = [
+    "evaluate_policy",
+    "expected_regret",
+    "cumulative_regret",
+]

--- a/sirius_rl/eval/regret.py
+++ b/sirius_rl/eval/regret.py
@@ -1,0 +1,32 @@
+"""Regret utilities for bandit-style environments."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence
+
+
+def expected_regret(probs: Sequence[float], action: int) -> float:
+    """Return the instantaneous expected regret for taking ``action``.
+
+    Regret is defined as the difference between the optimal arm probability and
+    the chosen arm's probability.
+    """
+
+    if not probs:
+        raise ValueError("probs must be non-empty")
+    if action < 0 or action >= len(probs):
+        raise ValueError("action out of bounds")
+
+    best = max(probs)
+    return float(best - probs[action])
+
+
+def cumulative_regret(probs: Sequence[float], actions: Iterable[int]) -> List[float]:
+    """Compute cumulative expected regret sequence for a list of actions."""
+
+    regrets: List[float] = []
+    total = 0.0
+    for action in actions:
+        total += expected_regret(probs, action)
+        regrets.append(total)
+    return regrets

--- a/sirius_rl/eval/runner.py
+++ b/sirius_rl/eval/runner.py
@@ -1,0 +1,139 @@
+"""Evaluation harness for environments and policies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from sirius_rl.env.base import Environment, StepResult
+from sirius_rl.utils.logging import JsonlLogger
+from sirius_rl.utils.seed import create_rng
+
+Policy = Callable[[Any], Any]
+
+
+@dataclass
+class EpisodeResult:
+    total_reward: float
+    steps: int
+    regrets: Optional[List[float]] = None
+
+
+@dataclass
+class EvaluationResult:
+    episode_results: List[EpisodeResult]
+
+    @property
+    def average_reward(self) -> float:
+        if not self.episode_results:
+            return 0.0
+        return sum(ep.total_reward for ep in self.episode_results) / len(
+            self.episode_results
+        )
+
+    @property
+    def average_regret(self) -> Optional[float]:
+        regrets = [ep.regrets[-1] for ep in self.episode_results if ep.regrets]
+        if not regrets:
+            return None
+        return sum(regrets) / len(regrets)
+
+
+def _run_single_episode(
+    env: Environment,
+    policy: Policy,
+    *,
+    steps: int,
+    seed: Optional[int],
+    episode_index: int,
+    logger: Optional[JsonlLogger],
+    regret_fn: Optional[Callable[[Any], float]],
+) -> EpisodeResult:
+    observation = env.reset(seed=seed)
+    regrets: List[float] = []
+    cumulative_regret = 0.0
+    total_reward = 0.0
+    step_count = -1
+
+    for t in range(steps):
+        step_count = t
+        action = policy(observation)
+        step_result: StepResult = env.step(action)
+        observation = step_result.observation
+        total_reward += step_result.reward
+        if regret_fn:
+            cumulative_regret += regret_fn(action)
+            regrets.append(cumulative_regret)
+
+        if logger:
+            logger.log(
+                seed=seed,
+                t=t,
+                episode=episode_index,
+                reward=step_result.reward,
+                info=step_result.info,
+                extra={
+                    "action": action,
+                    "observation": observation,
+                },
+            )
+
+        if step_result.terminated:
+            break
+
+    return EpisodeResult(total_reward=total_reward, steps=max(step_count + 1, 0), regrets=regrets or None)
+
+
+def evaluate_policy(
+    env: Environment,
+    policy: Policy,
+    *,
+    steps: int,
+    episodes: int = 1,
+    seed: Optional[int] = None,
+    logger: Optional[JsonlLogger] = None,
+    regret_builder: Optional[Callable[[Any], Callable[[Any], float]]] = None,
+) -> EvaluationResult:
+    """Evaluate a policy on the provided environment.
+
+    Parameters
+    ----------
+    env:
+        Environment implementing the base protocol.
+    policy:
+        Callable mapping observation to an action.
+    steps:
+        Maximum steps per episode.
+    episodes:
+        Number of episodes to run.
+    seed:
+        Optional master seed for reproducibility.
+    logger:
+        Optional JsonlLogger to emit per-step records.
+    regret_builder:
+        Optional callable producing a regret function given the environment. It
+        should return a function that accepts an action and returns regret.
+    """
+
+    runner_rng = create_rng(seed)
+    episode_results: List[EpisodeResult] = []
+
+    regret_fn: Optional[Callable[[Any], float]] = None
+    if regret_builder:
+        regret_fn = regret_builder(env)
+
+    for ep in range(episodes):
+        episode_seed = runner_rng.randrange(1_000_000) if seed is not None else None
+        episode_results.append(
+            _run_single_episode(
+                env,
+                policy,
+                steps=steps,
+                seed=episode_seed,
+                episode_index=ep,
+                logger=logger,
+                regret_fn=regret_fn,
+            )
+        )
+
+    return EvaluationResult(episode_results=episode_results)

--- a/sirius_rl/utils/__init__.py
+++ b/sirius_rl/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Utility helpers for Sirius RL."""
+
+from .seed import create_rng
+from .logging import JsonlLogger
+
+__all__ = [
+    "create_rng",
+    "JsonlLogger",
+]

--- a/sirius_rl/utils/logging.py
+++ b/sirius_rl/utils/logging.py
@@ -1,0 +1,54 @@
+"""Lightweight JSONL logger for RL training and evaluation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class JsonlLogger:
+    """Append-only JSON Lines logger with a fixed schema."""
+
+    path: Path
+    run_id: Optional[str] = None
+    _mandatory_fields: tuple[str, ...] = field(
+        default=("run_id", "seed", "t", "episode", "reward", "info"),
+        init=False,
+    )
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(
+        self,
+        *,
+        seed: Optional[int],
+        t: int,
+        episode: int,
+        reward: float,
+        info: Dict[str, Any],
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Write a single event to the JSONL file."""
+
+        record: Dict[str, Any] = {
+            "run_id": self.run_id,
+            "seed": seed,
+            "t": t,
+            "episode": episode,
+            "reward": float(reward),
+            "info": info,
+        }
+        if extra:
+            record.update(extra)
+
+        missing = [field for field in self._mandatory_fields if field not in record]
+        if missing:
+            raise ValueError(f"Missing required log fields: {missing}")
+
+        with self.path.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/sirius_rl/utils/seed.py
+++ b/sirius_rl/utils/seed.py
@@ -1,0 +1,15 @@
+"""Randomness helpers for deterministic experiments."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import random
+
+
+def create_rng(seed: Optional[int] = None) -> random.Random:
+    """Create a Python ``random.Random`` instance for reproducibility."""
+
+    rng = random.Random()
+    rng.seed(seed)
+    return rng

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is importable for local packages.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -1,0 +1,52 @@
+from sirius_rl.env.bandit import BernoulliBanditEnv
+from sirius_rl.eval import regret
+from sirius_rl.eval.runner import evaluate_policy
+from sirius_rl.utils.seed import create_rng
+
+
+def test_bandit_seed_reproducible():
+    probs = [0.3, 0.6]
+    actions = [0, 1, 0, 1, 1]
+
+    env_a = BernoulliBanditEnv(probs)
+    env_b = BernoulliBanditEnv(probs)
+
+    env_a.reset(seed=99)
+    env_b.reset(seed=99)
+
+    rewards_a = [env_a.step(a).reward for a in actions]
+    rewards_b = [env_b.step(a).reward for a in actions]
+
+    assert rewards_a == rewards_b
+
+
+def test_expected_regret():
+    probs = [0.1, 0.9]
+    actions = [0, 1, 0, 1]
+    cumulative = regret.cumulative_regret(probs, actions)
+
+    assert cumulative[-1] == (0.9 - 0.1) * 2
+    assert cumulative == [0.8, 0.8, 1.6, 1.6]
+
+
+def test_random_policy_baseline_regret_and_reward():
+    probs = [0.2, 0.8]
+    env = BernoulliBanditEnv(probs)
+    rng = create_rng(7)
+
+    def random_policy(_obs):
+        return rng.randrange(len(probs))
+
+    result = evaluate_policy(
+        env,
+        random_policy,
+        steps=20,
+        episodes=5,
+        seed=2024,
+        regret_builder=lambda e: e.regret_function(),
+    )
+
+    # Deterministic thanks to fixed seeds
+    assert result.average_reward == 10.2
+    assert result.average_regret is not None
+    assert round(result.average_regret, 3) == 6.12

--- a/tests/test_gridworld_dp.py
+++ b/tests/test_gridworld_dp.py
@@ -1,0 +1,47 @@
+from sirius_rl.algorithms.dp import policy_iteration, value_iteration
+from sirius_rl.env.gridworld import GridWorldEnv
+
+
+def sid(x: int, y: int, width: int) -> int:
+    return y * width + x
+
+
+def build_env():
+    width, height = 4, 4
+    return GridWorldEnv(
+        width=width,
+        height=height,
+        walls=[(1, 1)],
+        start=(0, 0),
+        terminals=[(3, 3)],
+        reward_map={(3, 3): 1.0},
+        step_penalty=-0.04,
+    )
+
+
+def test_value_iteration_policy_moves_toward_goal():
+    env = build_env()
+    V, policy = value_iteration(env, gamma=0.9, theta=1e-5)
+
+    start_action = policy[sid(0, 0, env.width)]
+    assert start_action in (1, 2)  # right or down
+
+    near_goal_state = sid(2, 3, env.width)
+    assert policy[near_goal_state] == 1  # move right into the goal
+
+    assert V[sid(3, 3, env.width)] == 0.0  # terminal state's value remains zero
+
+
+def test_policy_iteration_converges_to_reasonable_policy():
+    env = build_env()
+    V, policy = policy_iteration(env, gamma=0.9, theta=1e-5)
+
+    start_action = policy[sid(0, 0, env.width)]
+    assert start_action in (1, 2)
+
+    near_wall_state = sid(1, 0, env.width)
+    assert policy[near_wall_state] in (1, 2)  # avoid walking back into start/left
+
+    near_goal_state = sid(2, 3, env.width)
+    assert V[near_goal_state] > V[sid(0, 0, env.width)]
+    assert V[sid(0, 0, env.width)] > 0.0

--- a/tests/test_seed_repro.py
+++ b/tests/test_seed_repro.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from sirius_rl.env.bandit import BernoulliBanditEnv
+from sirius_rl.eval.runner import evaluate_policy
+from sirius_rl.utils.logging import JsonlLogger
+
+
+def test_runner_reproducible():
+    probs = [0.2, 0.8]
+    env1 = BernoulliBanditEnv(probs)
+    env2 = BernoulliBanditEnv(probs)
+    policy = lambda obs: 1  # always pick the best arm
+
+    res1 = evaluate_policy(env1, policy, steps=10, episodes=3, seed=42)
+    res2 = evaluate_policy(env2, policy, steps=10, episodes=3, seed=42)
+
+    assert res1.average_reward == res2.average_reward
+    assert [ep.total_reward for ep in res1.episode_results] == [
+        ep.total_reward for ep in res2.episode_results
+    ]
+
+
+def test_jsonl_logger_schema(tmp_path: Path):
+    log_path = tmp_path / "train.log"
+    logger = JsonlLogger(log_path, run_id="run-1")
+    logger.log(seed=123, t=0, episode=0, reward=1.0, info={"note": "ok"})
+
+    with log_path.open() as fp:
+        line = fp.readline()
+    record = json.loads(line)
+    for field in ("run_id", "seed", "t", "episode", "reward", "info"):
+        assert field in record
+    assert record["run_id"] == "run-1"
+    assert record["seed"] == 123
+    assert record["t"] == 0
+    assert record["episode"] == 0
+    assert record["reward"] == 1.0
+    assert record["info"] == {"note": "ok"}


### PR DESCRIPTION
## Summary
- add sirius_rl package with environment protocol, RNG/logging helpers, evaluation runner, and regret utilities
- implement Bernoulli bandit environment plus GridWorld with value/policy iteration and supporting tests
- document the new Python baseline in RL course materials

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bea39fbac833396ccef7f13b9ae23)