### PR TITLE
Add bandit bandit agents and benchmarking utilities

### DIFF
--- a/rl/index.html
+++ b/rl/index.html
@@ -133,6 +133,19 @@
       </div>
       <div class="callout warn">A_j に含めた義務は証拠ログとセットで残してください。影響なしの場合も「A_j: none」を明記するとレビューがスムーズです。</div>
     </section>
+
+    <section class="rl-card rl-stack">
+      <div class="badge">Mission 01: Bandit</div>
+      <h2>探索と活用の入口を自前実装で体験</h2>
+      <p>Bernoulli Bandit を題材に、ε-greedy / UCB / Thompson Sampling を自前で実装し、統計的にベンチマークします。外部RLライブラリは禁止、seedとステップ数を固定して再現性を確保してください。</p>
+      <div class="callout good">提出物（目安）</div>
+      <ul>
+        <li><code>sirius_rl/agents/bandit.py</code> に 3エージェント（EpsilonGreedyAgent, UCB1Agent, ThompsonSamplingBernoulliAgent）を実装。</li>
+        <li><code>sirius_rl/eval/bandit_bench.py</code> で複数seed平均の reward / regret を計測するハーネスを追加。</li>
+        <li><code>tests/test_bandit_agents.py</code> で random baseline より平均regretが低いことを統計的に確認。</li>
+      </ul>
+      <div class="callout warn">CIを安定させるため、seedとステップ数を明示し、判定は平均値/相対評価で設定してください。</div>
+    </section>
   </main>
 
   <script src="../bt30/altair_shared.js"></script>

--- a/sirius_rl/__init__.py
+++ b/sirius_rl/__init__.py
@@ -5,4 +5,5 @@ __all__ = [
     "utils",
     "eval",
     "algorithms",
+    "agents",
 ]

--- a/sirius_rl/agents/__init__.py
+++ b/sirius_rl/agents/__init__.py
@@ -1,0 +1,17 @@
+"""Agent implementations for Sirius RL tasks."""
+
+from sirius_rl.agents.bandit import (
+    BanditAgent,
+    BetaParams,
+    EpsilonGreedyAgent,
+    ThompsonSamplingBernoulliAgent,
+    UCB1Agent,
+)
+
+__all__ = [
+    "BanditAgent",
+    "BetaParams",
+    "EpsilonGreedyAgent",
+    "ThompsonSamplingBernoulliAgent",
+    "UCB1Agent",
+]

--- a/sirius_rl/agents/bandit.py
+++ b/sirius_rl/agents/bandit.py
@@ -1,0 +1,124 @@
+"""Bandit agents implemented for exploration/exploitation exercises."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+from sirius_rl.utils.seed import create_rng
+
+
+class BanditAgent:
+    """Interface for bandit agents.
+
+    Agents map observations (often ``None`` in bandit settings) to actions and
+    can optionally learn from rewards via ``update``.
+    """
+
+    def __init__(self, n_actions: int, seed: Optional[int] = None) -> None:
+        if n_actions <= 0:
+            raise ValueError("n_actions must be positive")
+        self.n_actions = n_actions
+        self.rng = create_rng(seed)
+
+    def act(self, observation=None) -> int:  # noqa: ANN001
+        raise NotImplementedError
+
+    def update(self, action: int, reward: float) -> None:
+        del action, reward
+        return None
+
+    def __call__(self, observation=None) -> int:  # noqa: ANN001
+        return self.act(observation)
+
+
+class EpsilonGreedyAgent(BanditAgent):
+    """Classic epsilon-greedy agent with sample-average value estimates."""
+
+    def __init__(self, n_actions: int, epsilon: float = 0.1, seed: Optional[int] = None) -> None:
+        if epsilon < 0.0 or epsilon > 1.0:
+            raise ValueError("epsilon must be in [0, 1]")
+        super().__init__(n_actions, seed=seed)
+        self.epsilon = epsilon
+        self.counts = [0] * n_actions
+        self.estimates = [0.0] * n_actions
+
+    def act(self, observation=None) -> int:  # noqa: ANN001
+        untried_actions = [i for i, c in enumerate(self.counts) if c == 0]
+        if untried_actions:
+            return self.rng.choice(untried_actions)
+
+        if self.rng.random() < self.epsilon:
+            return self.rng.randrange(self.n_actions)
+
+        max_value = max(self.estimates)
+        best_actions = [i for i, v in enumerate(self.estimates) if v == max_value]
+        return self.rng.choice(best_actions)
+
+    def update(self, action: int, reward: float) -> None:
+        self.counts[action] += 1
+        count = self.counts[action]
+        estimate = self.estimates[action]
+        self.estimates[action] = estimate + (reward - estimate) / count
+
+
+class UCB1Agent(BanditAgent):
+    """Upper Confidence Bound (UCB1) agent using Hoeffding bounds."""
+
+    def __init__(self, n_actions: int, c: float = 1.0, seed: Optional[int] = None) -> None:
+        if c <= 0:
+            raise ValueError("c must be positive")
+        super().__init__(n_actions, seed=seed)
+        self.c = c
+        self.counts = [0] * n_actions
+        self.estimates = [0.0] * n_actions
+        self.total_steps = 0
+
+    def act(self, observation=None) -> int:  # noqa: ANN001
+        self.total_steps += 1
+
+        untried_actions = [i for i, c in enumerate(self.counts) if c == 0]
+        if untried_actions:
+            return self.rng.choice(untried_actions)
+
+        ucb_scores = []
+        log_total = math.log(self.total_steps)
+        for estimate, count in zip(self.estimates, self.counts):
+            bonus = math.sqrt((self.c * log_total) / count)
+            ucb_scores.append(estimate + bonus)
+
+        max_score = max(ucb_scores)
+        best_actions = [i for i, score in enumerate(ucb_scores) if score == max_score]
+        return self.rng.choice(best_actions)
+
+    def update(self, action: int, reward: float) -> None:
+        self.counts[action] += 1
+        count = self.counts[action]
+        estimate = self.estimates[action]
+        self.estimates[action] = estimate + (reward - estimate) / count
+
+
+class ThompsonSamplingBernoulliAgent(BanditAgent):
+    """Thompson sampling agent for Bernoulli rewards using Beta priors."""
+
+    def __init__(self, n_actions: int, seed: Optional[int] = None) -> None:
+        super().__init__(n_actions, seed=seed)
+        self.params = [BetaParams() for _ in range(n_actions)]
+
+    def act(self, observation=None) -> int:  # noqa: ANN001
+        samples = [self.rng.betavariate(p.alpha, p.beta) for p in self.params]
+        max_value = max(samples)
+        best_actions = [i for i, v in enumerate(samples) if v == max_value]
+        return self.rng.choice(best_actions)
+
+    def update(self, action: int, reward: float) -> None:
+        params = self.params[action]
+        params.alpha += reward
+        params.beta += 1 - reward
+
+
+@dataclass
+class BetaParams:
+    alpha: float = 1.0
+    beta: float = 1.0

--- a/sirius_rl/eval/bandit_bench.py
+++ b/sirius_rl/eval/bandit_bench.py
@@ -1,0 +1,77 @@
+"""Benchmark utilities for bandit agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional
+
+from sirius_rl.agents.bandit import BanditAgent
+from sirius_rl.env.bandit import BernoulliBanditEnv
+
+
+@dataclass
+class BanditBenchmarkResult:
+    average_reward: float
+    average_regret: float
+    rewards: List[float]
+    regrets: List[float]
+
+
+def run_bandit_benchmark(
+    env: BernoulliBanditEnv,
+    agent_factory: Callable[[Optional[int]], BanditAgent],
+    *,
+    seeds: Iterable[int],
+    steps: int,
+) -> BanditBenchmarkResult:
+    """Run a bandit benchmark across multiple seeds.
+
+    Parameters
+    ----------
+    env:
+        Prototype environment. The benchmark will recreate environments with
+        the same probability vector for each seed.
+    agent_factory:
+        Callable that returns a fresh agent when provided a seed.
+    seeds:
+        Iterable of seeds to average over.
+    steps:
+        Number of pulls per seed.
+    """
+
+    if steps <= 0:
+        raise ValueError("steps must be positive")
+
+    probs = env.probs
+    regrets: List[float] = []
+    rewards: List[float] = []
+    seed_list = list(seeds)
+    if not seed_list:
+        raise ValueError("seeds must be non-empty")
+
+    for seed in seed_list:
+        run_env = BernoulliBanditEnv(probs, seed=seed)
+        agent = agent_factory(seed)
+        regret_fn = run_env.regret_function()
+
+        total_reward = 0.0
+        cumulative_regret = 0.0
+
+        for _ in range(steps):
+            action = agent(None)
+            result = run_env.step(action)
+            total_reward += result.reward
+            cumulative_regret += regret_fn(action)
+            agent.update(action, result.reward)
+
+        regrets.append(cumulative_regret / steps)
+        rewards.append(total_reward / steps)
+
+    avg_regret = sum(regrets) / len(regrets)
+    avg_reward = sum(rewards) / len(rewards)
+    return BanditBenchmarkResult(
+        average_reward=avg_reward,
+        average_regret=avg_regret,
+        rewards=rewards,
+        regrets=regrets,
+    )

--- a/tests/test_bandit_agents.py
+++ b/tests/test_bandit_agents.py
@@ -1,0 +1,63 @@
+import math
+
+from sirius_rl.agents.bandit import (
+    EpsilonGreedyAgent,
+    ThompsonSamplingBernoulliAgent,
+    UCB1Agent,
+)
+from sirius_rl.env.bandit import BernoulliBanditEnv
+from sirius_rl.eval.bandit_bench import run_bandit_benchmark
+from sirius_rl.utils.seed import create_rng
+
+
+class RandomAgent:
+    def __init__(self, n_actions: int, seed: int) -> None:
+        self.n_actions = n_actions
+        self.rng = create_rng(seed)
+
+    def __call__(self, observation=None):  # noqa: ANN001
+        return self.rng.randrange(self.n_actions)
+
+    def update(self, action: int, reward: float) -> None:
+        return None
+
+
+def test_bandit_agents_beat_random_baseline():
+    probs = [0.1, 0.2, 0.8, 0.4, 0.3]
+    steps = 400
+    seeds = list(range(5))
+    env = BernoulliBanditEnv(probs)
+
+    baseline = run_bandit_benchmark(
+        env, lambda seed: RandomAgent(len(probs), seed), seeds=seeds, steps=steps
+    )
+
+    epsilon_result = run_bandit_benchmark(
+        env,
+        lambda seed: EpsilonGreedyAgent(len(probs), epsilon=0.1, seed=seed),
+        seeds=seeds,
+        steps=steps,
+    )
+    ucb_result = run_bandit_benchmark(
+        env,
+        lambda seed: UCB1Agent(len(probs), c=0.5, seed=seed),
+        seeds=seeds,
+        steps=steps,
+    )
+    thompson_result = run_bandit_benchmark(
+        env,
+        lambda seed: ThompsonSamplingBernoulliAgent(len(probs), seed=seed),
+        seeds=seeds,
+        steps=steps,
+    )
+
+    assert epsilon_result.average_regret < baseline.average_regret * 0.75
+    assert epsilon_result.average_reward > baseline.average_reward
+
+    assert ucb_result.average_regret < epsilon_result.average_regret * 0.95
+    assert thompson_result.average_regret < epsilon_result.average_regret * 0.95
+
+    assert math.isclose(baseline.average_regret, 0.44, rel_tol=0.1)
+    assert epsilon_result.average_reward > 0.6
+    assert ucb_result.average_reward > 0.65
+    assert thompson_result.average_reward > 0.65


### PR DESCRIPTION
## Summary
- implement epsilon-greedy, UCB1, and Thompson sampling bandit agents and expose them from the package
- add a multi-seed bandit benchmarking helper and regression-style tests that compare agents against a random baseline
- document the Mission 01 Bandit deliverables on the RL index page

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf010795483339e766e678d8a4679)