### PR TITLE
Add mastery estimation and Goldilocks suggestions

### DIFF
--- a/docs/rl/ops_goldilocks.md
+++ b/docs/rl/ops_goldilocks.md
@@ -1,0 +1,47 @@
+# Goldilocks 帯の運用メモ
+
+テストの Outcome（Pass/Fail）から Beta 分布で学習者の mastery を推定し、次のガイドレベルを提案するための最小実装です。
+
+## 入力フォーマット
+
+- JSON または JSONL を受け付けます。
+- 推奨構造（JSON の例）:
+
+```json
+{
+  "current_level": 2,
+  "attempts": [
+    {"outcome": "pass", "time_min": 35, "trials": 2},
+    {"outcome": "fail", "time_min": 42, "trials": 1}
+  ]
+}
+```
+
+- JSONL の場合は 1 行 1 レコードで、`attempts` 配列を使わずに直接 `outcome` を含めても処理されます。
+- `outcome` は `pass` / `fail`（大文字小文字は問わない）のみを評価対象とし、`time_min` や `trials` はログ保持用です（現状の推定では未使用）。
+
+## 推定と更新ロジック
+
+- 事前分布は Beta(α=1, β=1) を既定とし、Pass で α、Fail で β を +1 更新します。
+- 推定 mastery は Beta 分布の平均 `p = α / (α + β)` を用います。
+
+## Goldilocks 帯の推奨ルール（既定）
+
+- `p < 0.55` : ガイドを手厚くする（ガイド Lv を 1 上げる）
+- `0.55 <= p <= 0.80` : 現状維持
+- `p > 0.80` : ガイドを絞る（ガイド Lv を 1 下げる）
+- 境界値やステップ幅は `scripts/suggest_next.py` の引数で上書きできます。
+
+## CLI の使い方
+
+```bash
+python scripts/suggest_next.py --input path/to/log.json
+```
+
+オプション:
+
+- `--current-level` : 入力に `current_level` がない場合の明示指定
+- `--alpha0` / `--beta0` : Beta 事前分布の初期値（既定は 1.0 / 1.0）
+- `--easier-than` / `--harder-than` / `--step` / `--min-level` / `--max-level` : Goldilocks ルールの上書き
+
+出力は推定された `p` と `next_level` を含む JSON で、標準出力に表示されます。

--- a/scripts/suggest_next.py
+++ b/scripts/suggest_next.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+"""CLI for suggesting the next guide level using Goldilocks band heuristics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from sirius_rl.obs.mastery import DEFAULT_RULES, mean_p, recommend_guide_level, update_beta
+
+
+def parse_attempts(payload: Any) -> Tuple[List[Dict[str, Any]], Any]:
+    """Extract attempts and a current level (if present) from an object."""
+
+    attempts: List[Dict[str, Any]] = []
+    current_level = None
+
+    if isinstance(payload, dict):
+        attempts = payload.get("attempts", [])
+        current_level = payload.get("current_level")
+        # Allow a single attempt at the top level
+        if not attempts and "outcome" in payload:
+            attempts = [payload]
+    elif isinstance(payload, list):
+        attempts = payload
+
+    return attempts, current_level
+
+
+def load_input(path: Path) -> Tuple[List[Dict[str, Any]], Any]:
+    """Load JSON or JSONL input."""
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+        attempts, current_level = parse_attempts(payload)
+        return attempts, current_level
+    except json.JSONDecodeError:
+        attempts: List[Dict[str, Any]] = []
+        current_level = None
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            record_attempts, record_level = parse_attempts(record)
+            attempts.extend(record_attempts)
+            if current_level is None and record_level is not None:
+                current_level = record_level
+        return attempts, current_level
+
+
+def outcome_to_bool(outcome: Any) -> Any:
+    """Normalize an outcome value to a boolean success flag."""
+
+    if isinstance(outcome, str):
+        normalized = outcome.strip().lower()
+        if normalized in {"pass", "passed", "success"}:
+            return True
+        if normalized in {"fail", "failed"}:
+            return False
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Path to JSON or JSONL log.")
+    parser.add_argument("--current-level", type=int, help="Override the current guide level.")
+    parser.add_argument("--alpha0", type=float, default=1.0, help="Prior alpha for Beta.")
+    parser.add_argument("--beta0", type=float, default=1.0, help="Prior beta for Beta.")
+    parser.add_argument(
+        "--easier-than",
+        type=float,
+        default=DEFAULT_RULES["easier_than"],
+        help="Threshold below which guidance is increased (easier).",
+    )
+    parser.add_argument(
+        "--harder-than",
+        type=float,
+        default=DEFAULT_RULES["harder_than"],
+        help="Threshold above which guidance is decreased (harder).",
+    )
+    parser.add_argument(
+        "--step",
+        type=int,
+        default=DEFAULT_RULES["step"],
+        help="Amount to adjust the guide level.",
+    )
+    parser.add_argument("--min-level", type=int, default=None, help="Minimum guide level bound.")
+    parser.add_argument("--max-level", type=int, default=None, help="Maximum guide level bound.")
+
+    args = parser.parse_args()
+
+    attempts, level_from_input = load_input(args.input)
+    current_level = args.current_level if args.current_level is not None else level_from_input
+
+    if current_level is None:
+        raise SystemExit("current_level is required either in the input or via --current-level.")
+
+    alpha, beta = args.alpha0, args.beta0
+    for attempt in attempts:
+        flag = outcome_to_bool(attempt.get("outcome"))
+        if flag is None:
+            print(f"Skipping attempt with unknown outcome: {attempt}", file=sys.stderr)
+            continue
+        alpha, beta = update_beta(alpha, beta, flag)
+
+    p = mean_p(alpha, beta)
+    rules = {
+        "easier_than": args.easier_than,
+        "harder_than": args.harder_than,
+        "step": args.step,
+        "min_level": args.min_level,
+        "max_level": args.max_level,
+    }
+    next_level = recommend_guide_level(p, current_level, rules)
+
+    output = {
+        "alpha": alpha,
+        "beta": beta,
+        "p": p,
+        "current_level": current_level,
+        "next_level": next_level,
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/sirius_rl/__init__.py
+++ b/sirius_rl/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "eval",
     "algorithms",
     "agents",
+    "obs",
 ]

--- a/sirius_rl/obs/__init__.py
+++ b/sirius_rl/obs/__init__.py
@@ -1,0 +1,3 @@
+"""Observation and mastery estimation utilities."""
+
+__all__ = ["mastery"]

--- a/sirius_rl/obs/mastery.py
+++ b/sirius_rl/obs/mastery.py
@@ -1,0 +1,76 @@
+"""Mastery estimation utilities for Goldilocks-style guide level suggestions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Default thresholds for the Goldilocks band logic.
+DEFAULT_RULES: Dict[str, Any] = {
+    "easier_than": 0.55,
+    "harder_than": 0.80,
+    "step": 1,
+    "min_level": None,
+    "max_level": None,
+}
+
+
+def update_beta(alpha: float, beta: float, success: bool) -> tuple[float, float]:
+    """Update Beta distribution parameters given a new Bernoulli outcome."""
+
+    if alpha <= 0 or beta <= 0:
+        raise ValueError("Alpha and beta must be positive.")
+
+    if success:
+        alpha += 1
+    else:
+        beta += 1
+    return alpha, beta
+
+
+def mean_p(alpha: float, beta: float) -> float:
+    """Return the mean of a Beta distribution."""
+
+    if alpha <= 0 or beta <= 0:
+        raise ValueError("Alpha and beta must be positive.")
+    return alpha / (alpha + beta)
+
+
+def recommend_guide_level(
+    p: float,
+    current_level: int,
+    rules: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Recommend the next guide level using Goldilocks band thresholds.
+
+    The ``rules`` dictionary can include:
+    - ``easier_than``: threshold below which the level should increase (easier).
+    - ``harder_than``: threshold above which the level should decrease (harder).
+    - ``step``: increment/decrement applied to the current level.
+    - ``min_level`` / ``max_level``: optional bounds for the recommended level.
+    """
+
+    selected_rules: Dict[str, Any] = {**DEFAULT_RULES, **(rules or {})}
+    next_level = current_level
+
+    if p < selected_rules["easier_than"]:
+        next_level = current_level + selected_rules["step"]
+    elif p > selected_rules["harder_than"]:
+        next_level = current_level - selected_rules["step"]
+
+    min_level = selected_rules.get("min_level")
+    max_level = selected_rules.get("max_level")
+
+    if min_level is not None:
+        next_level = max(min_level, next_level)
+    if max_level is not None:
+        next_level = min(max_level, next_level)
+
+    return next_level
+
+
+__all__ = [
+    "DEFAULT_RULES",
+    "update_beta",
+    "mean_p",
+    "recommend_guide_level",
+]

--- a/tests/test_mastery.py
+++ b/tests/test_mastery.py
@@ -1,0 +1,25 @@
+from sirius_rl.obs.mastery import DEFAULT_RULES, mean_p, recommend_guide_level, update_beta
+
+
+def test_update_beta_and_mean():
+    alpha, beta = 1.0, 1.0
+
+    alpha, beta = update_beta(alpha, beta, True)
+    assert (alpha, beta) == (2.0, 1.0)
+
+    alpha, beta = update_beta(alpha, beta, False)
+    assert (alpha, beta) == (2.0, 2.0)
+
+    assert mean_p(alpha, beta) == 0.5
+
+
+def test_recommend_guide_level():
+    rules = {**DEFAULT_RULES, "min_level": 1, "max_level": 5}
+
+    assert recommend_guide_level(0.4, 3, rules) == 4  # easier
+    assert recommend_guide_level(0.6, 3, rules) == 3  # stay
+    assert recommend_guide_level(0.9, 3, rules) == 2  # harder
+
+    # Respect bounds
+    assert recommend_guide_level(0.2, 5, rules) == 5
+    assert recommend_guide_level(0.95, 1, rules) == 1


### PR DESCRIPTION
## Summary
- add mastery utilities for Beta-based mastery estimation and Goldilocks guide recommendations
- provide a CLI that reads JSON/JSONL logs and suggests the next guide level
- document the Goldilocks workflow and add regression tests for beta updates and guide selection

## Time / Trials / Outcome
- Time: 60 min / Trials: 1
- Outcome: Pass

## A_j (Impacted obligations)
- obs.01, obs.02, gp.ops.01

## Test Evidence
- `python -m pytest`

## Impact / Risk
- Impact: CLI tooling, docs, new observation/mastery module
- Risk: thresholds are currently heuristic defaults; real-world data may require tuning


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf27bcbc483339577000a3293cefb)