### PR TITLE
Split Electron desktop backlog into EPIC and individual issue files

### DIFF
--- a/backlog/S-ENV-ELECTRON-01.md
+++ b/backlog/S-ENV-ELECTRON-01.md
@@ -1,0 +1,47 @@
+# S-ENV-ELECTRON Issue 1: Electronラッパー雛形追加
+
+```md
+TITLE: [desktop] Electronアプリ雛形追加（desktop/）
+LABELS: S-ENV, electron, desktop, P?
+S_COLUMN: S-ENV
+DEPENDS_ON:
+EST_SIZE: M
+
+## S（Spec）/ 仕様
+目的：
+- 既存のWeb（静的HTML）をWindowsデスクトップアプリのウィンドウで表示。`npm run start` で起動できる雛形を作る。
+
+背景/前提：
+- `index.html` から `bt7/`・`bt30/`・`qr/` 等へ相対リンク。
+- Electron推奨：`nodeIntegration:false`, `contextIsolation:true`, `sandbox:true`。([Electron][2])
+
+スコープ：
+- `desktop/` 追加、Electron最小構成
+- `BrowserWindow` で既存Webの `index.html` を表示
+- 外部リンク（http/https）はOS既定ブラウザで開く
+
+非スコープ：
+- Web資産同梱（Issue 2）
+- secure context（Issue 3）
+- インストーラ（Issue 4）
+
+受け入れ基準：
+- `cd desktop && npm install && npm run start` でウィンドウ起動
+- `index.html` が表示される
+- 外部リンクは既定ブラウザで開く
+
+## H（How）/ Codex Prompt
+制約：
+- 既存Web資産は触らない。変更は基本 `desktop/` 配下（`.gitignore` 追記のみ例外）。
+- `nodeIntegration:false`, `contextIsolation:true`, `sandbox:true` を設定。
+
+実装タスク：
+1) ルート直下に `desktop/` を新設し、`package.json`, `main.js`, `preload.js` を追加。`start` スクリプトを用意。
+2) `main.js` は 1200x820 程度のウィンドウを作り、repoルートの `index.html` を `loadFile` で表示。
+3) `setWindowOpenHandler` と `will-navigate` で http/https を `shell.openExternal`、それ以外はアプリ内遷移。
+4) `.gitignore` に `desktop/node_modules/` を追加（既存あれば不要）。
+
+完了確認：
+- `cd desktop && npm install && npm run start` で `index.html` 表示
+- 外部リンクが既定ブラウザで開く
+```

--- a/backlog/S-ENV-ELECTRON-02.md
+++ b/backlog/S-ENV-ELECTRON-02.md
@@ -1,0 +1,37 @@
+# S-ENV-ELECTRON Issue 2: Web資産同梱でオフライン起動
+
+```md
+TITLE: [desktop] Web資産を desktop/app に同期し、オフラインで起動できるようにする
+LABELS: S-ENV, electron, desktop, offline, P?
+S_COLUMN: S-ENV
+DEPENDS_ON: [desktop] Electronアプリ雛形追加（desktop/）
+EST_SIZE: M
+
+## S（Spec）/ 仕様
+目的：
+- Electronアプリがオフライン完結するよう、Web資産を `desktop/app/` に同期し、そこから起動する。
+
+スコープ：
+- `desktop/scripts/sync-web-assets.*` 追加でコピー
+- `npm run start` 前に `sync` 実行
+- Electronは `desktop/app/index.html` を読む
+
+受け入れ基準：
+- `npm run sync:web` で `desktop/app/index.html` が生成
+- `npm run start` で `desktop/app/index.html` 表示
+- `desktop/app/` は生成物として `.gitignore` 対応
+
+## H（How）/ Codex Prompt
+要件：
+- `desktop/app/` にWeb資産をコピー。同梱対象（存在する場合）：`index.html`, `index2.html`, `bt7/**`, `bt30/**`, `qr/**`。
+- 「固定リスト＋存在チェック」方式でOK。存在しないパスはスキップ＆ログ。
+
+実装タスク：
+1) `desktop/scripts/sync-web-assets.mjs` を作成。ソース：repo root、宛先：`desktop/app/`。Windows対応のパス処理。存在しないパスはスキップ＆ログ。
+2) `desktop/package.json` に `sync:web` と `prestart`（`npm run sync:web`）を追加。
+3) `desktop/main.js` を `desktop/app/index.html` ロードに変更。
+4) `.gitignore` に `desktop/app/`, `desktop/dist/` を追加。
+
+完了確認：
+- `cd desktop && npm install && npm run sync:web && npm run start` で起動。
+```

--- a/backlog/S-ENV-ELECTRON-03.md
+++ b/backlog/S-ENV-ELECTRON-03.md
@@ -1,0 +1,40 @@
+# S-ENV-ELECTRON Issue 3: app:// カスタムプロトコルと権限制御
+
+```md
+TITLE: [desktop] app:// カスタムプロトコルで読み込み（file://回避）＋ permission handler 実装
+LABELS: S-ENV, electron, desktop, security, P?
+S_COLUMN: S-ENV
+DEPENDS_ON: [desktop] Web資産を desktop/app に同期し、オフラインで起動できるようにする
+EST_SIZE: M
+
+## S（Spec）/ 仕様
+目的：
+- `file://` を避け `app://` カスタムプロトコルで secure context を確保し、カメラ等の権限を制御する。
+
+スコープ：
+- `app://` を `standard:true`, `secure:true` で登録
+- `protocol.handle('app', ...)` で `desktop/app/` を安全に配信（パストラバーサル防止）
+- permission handler で `media` のみ許可（`app://` 由来に限定）
+
+受け入れ基準：
+- `app://...` で起動している（`getURL()` が app://）
+- 相対リンク遷移（`bt7/` 等）が動く
+- カメラ権限が必要なページで許可動作が確認できる（手動）
+
+## H（How）/ Codex Prompt
+重要：
+- `protocol.registerSchemesAsPrivileged` は ready 前・一度だけ。([Electron][4])
+- `protocol.handle` 推奨。([Electron][4])
+
+実装タスク：
+1) `desktop/main.js` に `protocol.registerSchemesAsPrivileged([{ scheme:'app', privileges:{ standard:true, secure:true, supportFetchAPI:true } }])` を ready 前に追加。
+2) `app.whenReady()` 後に `protocol.handle('app', ...)` を登録し、`app://bundle/...` で `desktop/app/` を配信。`path.relative` でbase外アクセスを拒否。`net.fetch(pathToFileURL(...))` で返却。
+3) 起動URLを `win.loadURL('app://bundle/index.html')` に変更。
+4) `session.defaultSession.setPermissionRequestHandler` で `app://` 由来の `media` のみ許可、それ以外拒否。
+5) 外部リンク制御（既定ブラウザで開く）は維持。
+
+完了確認：
+- `npm run start` で `app://bundle/index.html` 起動
+- 相対遷移が壊れない
+- カメラ権限が必要なページで許可確認（手動）
+```

--- a/backlog/S-ENV-ELECTRON-04.md
+++ b/backlog/S-ENV-ELECTRON-04.md
@@ -1,0 +1,32 @@
+# S-ENV-ELECTRON Issue 4: electron-builder で NSIS インストーラ生成
+
+```md
+TITLE: [desktop] electron-builder で Windows(NSIS)インストーラを生成する
+LABELS: S-ENV, electron, desktop, release, P?
+S_COLUMN: S-ENV
+DEPENDS_ON: [desktop] app:// カスタムプロトコルで読み込み（file://回避）＋ permission handler 実装
+EST_SIZE: M
+
+## S（Spec）/ 仕様
+目的：
+- Windows向けに配布可能な NSIS インストーラ（.exe）を生成できるようにする。
+
+スコープ：
+- `desktop` に `electron-builder` を導入
+- `npm run dist:win` で `desktop/dist/` に .exe 生成
+- ビルド前に `sync:web` が走る
+
+受け入れ基準：
+- Windowsで `cd desktop && npm ci && npm run dist:win` が成功し、`dist` に .exe が出る
+- インストーラでインストール→起動できる（手動）
+
+## H（How）/ Codex Prompt
+実装タスク：
+1) `desktop/package.json` に `electron-builder` を devDependency 追加。
+2) scripts: `dist:win`: `npm run sync:web && electron-builder -w`。
+3) `build` 設定を追加：`appId`、`productName`、`files`（`main.js`, `preload.js`, `app/**/*` など）、`win.target: nsis`、`nsis` 最小設定。`directories.output` を `desktop/dist/` に。
+4) 生成物出力を `desktop/dist/` に統一。
+
+完了確認：
+- `npm run dist:win` で `desktop/dist/` にインストーラ生成。
+```

--- a/backlog/S-ENV-ELECTRON-05.md
+++ b/backlog/S-ENV-ELECTRON-05.md
@@ -1,0 +1,31 @@
+# S-ENV-ELECTRON Issue 5: GitHub Actions で Windows ビルド
+
+```md
+TITLE: [desktop] GitHub Actionsで Windowsインストーラをビルドし artifact としてアップロード
+LABELS: S-ENV, electron, desktop, ci, windows, P?
+S_COLUMN: S-ENV
+DEPENDS_ON: [desktop] electron-builder で Windows(NSIS)インストーラを生成する
+EST_SIZE: M
+
+## S（Spec）/ 仕様
+目的：
+- CIで Windows インストーラをビルドし、artifact として取得できるようにする。
+
+スコープ：
+- `.github/workflows/desktop-windows.yml` 追加
+- トリガー: `workflow_dispatch` と `push` tags `v*`
+- ジョブ: `windows-latest` で checkout → setup-node(lts) → `npm ci` → `npm run dist:win` → artifact upload
+
+受け入れ基準：
+- Actions 成功 & artifact から `.exe` ダウンロード可能
+
+## H（How）/ Codex Prompt
+実装タスク：
+1) `.github/workflows/desktop-windows.yml` を追加。
+2) トリガー: `workflow_dispatch`, `push` tags `v*`。
+3) runs-on: `windows-latest`; checkout; setup-node (`lts/*`); `cd desktop && npm ci`; `cd desktop && npm run dist:win`; `desktop/dist/*.exe` を upload-artifact（例: `windows-installer`）。
+4) npm cache を有効化できれば有効化。
+
+完了確認：
+- workflow 成功 & artifact から `.exe` 取得。
+```

--- a/backlog/S-ENV-ELECTRON-06.md
+++ b/backlog/S-ENV-ELECTRON-06.md
@@ -1,0 +1,29 @@
+# S-ENV-ELECTRON Issue 6: ドキュメント整備
+
+```md
+TITLE: [desktop] Electronアプリの開発・配布手順をドキュメント化
+LABELS: S-ENV, electron, desktop, docs, P?
+S_COLUMN: S-ENV
+DEPENDS_ON: [desktop] GitHub Actionsで Windowsインストーラをビルドし artifact としてアップロード
+EST_SIZE: S
+
+## S（Spec）/ 仕様
+目的：
+- 開発者が迷わないように、desktopアプリの手順を README として整備する。
+
+スコープ：
+- `desktop/README.md` を追加（QuickStart / build / よくある詰まり）
+- ルートREADMEに最小リンクを追加（任意）
+- secure context / permission / カメラ周りの注意を明記（`getUserMedia` はsecure context、Electron推奨設定を採用）
+
+受け入れ基準：
+- READMEの手順で `npm run start` / `npm run dist:win` が実行できる内容。
+
+## H（How）/ Codex Prompt
+実装タスク：
+1) `desktop/README.md` を追加し、前提（Node LTS）、開発起動 (`npm run start`)、同期 (`npm run sync:web` のコピー対象)、ビルド (`npm run dist:win` の成果物場所)、トラブルシュート（カメラ権限/SmartScreen/パス長など）を記載。
+2) ルート `README.md` があれば `desktop/README.md` へのリンクを控えめに追記。
+
+完了確認：
+- README記載の手順どおりに実行可能。
+```

--- a/backlog/S-ENV-ELECTRON-EPIC.md
+++ b/backlog/S-ENV-ELECTRON-EPIC.md
@@ -1,0 +1,52 @@
+# S-ENV-ELECTRON（Electronデスクトップ化 / 配布 / CI）EPIC
+
+```md
+TITLE: [EPIC][S-ENV] 既存Web資産をElectronデスクトップアプリ化し、配布・CIまで整備する
+LABELS: S-ENV, electron, desktop, windows
+S_COLUMN: S-ENV
+DEPENDS_ON:
+EST_SIZE: L
+
+## S（Spec）/ 仕様
+目的：
+- 既存の静的Web資産（`index.html` から `bt7/`・`bt30/`・`qr/`・`index2.html` へ相対リンク）をElectronでWindowsデスクトップ化し、オフライン・secure context・インストーラ・CIまで一気通貫で整備する。
+
+スコープ：
+- Electronラッパー雛形追加（`desktop/`）
+- Web資産同梱（オフライン対応）
+- `app://` カスタムプロトコルと権限ハンドリング（カメラ等）
+- electron-builderでNSISインストーラ生成
+- GitHub ActionsでWindowsビルド&artifact化
+- 開発/配布/トラブルシュートのドキュメント整備
+
+フォルダ構成（想定）：
+```
+/ (repo root)
+  index.html
+  index2.html
+  bt7/
+  bt30/
+  qr/
+  desktop/
+    package.json
+    main.js
+    preload.js
+    app/        # 同梱コピー先（生成物）
+    dist/       # ビルド成果物（生成物）
+    scripts/    # sync-web-assets など
+```
+
+進行方針：
+1) 雛形で「起動する」を最短で作る
+2) オフライン同梱
+3) secure context（`app://`）と権限制御
+4) インストーラ生成
+5) CI自動ビルド
+6) ドキュメントで運用支援
+
+受け入れ基準：
+- 下記Issue群が完了し、`npm run start` で起動、`npm run dist:win` でNSIS生成、Actionsからartifact取得できる状態。
+
+## H（How）/ Codex Prompt
+あなたは既存の静的WebリポジトリをElectronでWindows向けデスクトップ化し、オフライン対応・secure context対応・インストーラ生成・CI自動ビルド・ドキュメント整備まで段階的に進める。各Issueの範囲を尊重し、1PR=1Issueで進めること。
+```


### PR DESCRIPTION
### Motivation
- Break the previously monolithic Electron backlog into separate EPIC and issue files to enable a 1PR=1Issue workflow. 
- Make each implementation step explicit so work can proceed incrementally from an Electron skeleton to packaging, CI, and docs. 
- Preserve original specifications, acceptance criteria, and Codex prompts for each scoped issue to aid implementers. 
- Improve backlog maintainability and traceability by isolating concerns per file.

### Description
- Remove the combined backlog and add `backlog/S-ENV-ELECTRON-EPIC.md` plus `backlog/S-ENV-ELECTRON-01.md` through `backlog/S-ENV-ELECTRON-06.md` to represent the EPIC and six issues. 
- Each new file contains `TITLE`, `LABELS`, `S_COLUMN`, `DEPENDS_ON`, `EST_SIZE`, a `Spec` section, acceptance criteria, and a `How/Codex Prompt` section. 
- The issues cover the Electron app skeleton (`npm run start`), web-asset sync to `desktop/app` (`npm run sync:web`), `app://` protocol and permission handling, `electron-builder` NSIS packaging (`npm run dist:win`), a GitHub Actions Windows build workflow, and `desktop/README.md` documentation. 
- Files are organized for incremental implementation and to make CI/workflow and packaging tasks explicit for follow-up PRs.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c5425aa848333911702e0d4efde6c)