### PR TITLE
Sync desktop web assets for offline Electron startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 desktop/node_modules
-desktop/dist
-desktop/app
+desktop/dist/
+desktop/app/
 npm-debug.log*
 *.log

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -3,7 +3,7 @@
 const { app, BrowserWindow, shell } = require("electron");
 const path = require("path");
 
-const ROOT_INDEX_HTML = path.resolve(__dirname, "..", "index.html");
+const APP_INDEX_HTML = path.resolve(__dirname, "app", "index.html");
 
 function isExternalUrl(url) {
   return /^https?:\/\//i.test(url);
@@ -38,7 +38,7 @@ function createWindow() {
     }
   });
 
-  mainWindow.loadFile(ROOT_INDEX_HTML);
+  mainWindow.loadFile(APP_INDEX_HTML);
 }
 
 app.whenReady().then(() => {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "electron": "^30.0.9"
+        "electron": "^30.0.9",
+        "fs-extra": "^11.2.0"
       }
     },
     "node_modules/@electron/get": {
@@ -434,6 +435,21 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -597,6 +613,19 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -849,6 +878,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,9 +6,12 @@
   "author": "",
   "license": "MIT",
   "scripts": {
+    "sync:web": "node ./scripts/sync-web-assets.mjs",
+    "prestart": "npm run sync:web",
     "start": "electron ."
   },
   "devDependencies": {
-    "electron": "^30.0.9"
+    "electron": "^30.0.9",
+    "fs-extra": "^11.2.0"
   }
 }

--- a/desktop/scripts/sync-web-assets.mjs
+++ b/desktop/scripts/sync-web-assets.mjs
@@ -1,20 +1,15 @@
-"use strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fsExtra from "fs-extra";
 
-const fs = require("fs");
-const path = require("path");
-const fse = require("fs-extra");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const destinationRoot = path.resolve(__dirname, "..", "app");
 
-const assets = [
-  "index.html",
-  "index2.html",
-  "bt7",
-  "bt30",
-  "qr",
-  "course_dark.css"
-];
+const assets = ["index.html", "index2.html", "bt7", "bt30", "qr"];
 
 async function copyAsset(assetPath) {
   const source = path.join(repoRoot, assetPath);
@@ -25,16 +20,18 @@ async function copyAsset(assetPath) {
     return;
   }
 
-  await fse.copy(source, destination, { dereference: true });
+  await fsExtra.copy(source, destination, { dereference: true });
   console.log(`[sync-web] Copied: ${assetPath}`);
 }
 
 async function main() {
-  await fse.emptyDir(destinationRoot);
+  await fsExtra.emptyDir(destinationRoot);
+
   for (const asset of assets) {
     // eslint-disable-next-line no-await-in-loop
     await copyAsset(asset);
   }
+
   console.log(`[sync-web] Assets synced to: ${destinationRoot}`);
 }
 


### PR DESCRIPTION
### Motivation
- Make the Electron desktop app self-contained so it can run offline by bundling required web assets under `desktop/app/`.
- Ensure the app always loads the local copy of `index.html` rather than a repo-root file to avoid runtime dependency on the repo layout.

### Description
- Add an ESM sync script `desktop/scripts/sync-web-assets.mjs` that copies a fixed list of assets (`index.html`, `index2.html`, `bt7`, `bt30`, `qr`) from the repo root into `desktop/app/`, skipping and logging any missing paths. 
- Wire `sync:web` into `desktop/package.json` and run it before start via `prestart`, and add `fs-extra` as a dependency used by the script. 
- Change `desktop/main.js` to load `desktop/app/index.html` instead of the repo root `index.html`. 
- Update `.gitignore` to exclude generated `desktop/app/` and `desktop/dist/` directories and update the lockfile accordingly. 

### Testing
- Ran `cd desktop && npm install` which completed successfully. 
- Ran `cd desktop && npm run sync:web` which completed and logged copied assets to `desktop/app/`.
- The sync script reports skipped missing assets when applicable and exits with success on completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c618d85848333808c5bb6b82e8ed7)