### PR TITLE
Add app:// protocol handler and media permission gating

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,12 +1,90 @@
 "use strict";
 
-const { app, BrowserWindow, shell } = require("electron");
+const {
+  app,
+  BrowserWindow,
+  shell,
+  protocol,
+  session,
+  net
+} = require("electron");
+const { pathToFileURL } = require("url");
 const path = require("path");
 
-const APP_INDEX_HTML = path.resolve(__dirname, "app", "index.html");
+const APP_SCHEME = "app";
+const APP_HOST = "bundle";
+const APP_ROOT = path.resolve(__dirname, "app");
+const APP_ENTRYPOINT = `${APP_SCHEME}://${APP_HOST}/index.html`;
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: APP_SCHEME,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true
+    }
+  }
+]);
 
 function isExternalUrl(url) {
   return /^https?:\/\//i.test(url);
+}
+
+function resolveAssetPath(requestUrl) {
+  if (requestUrl.hostname !== APP_HOST) {
+    return null;
+  }
+
+  let pathname = decodeURIComponent(requestUrl.pathname);
+
+  if (!pathname || pathname === "/") {
+    pathname = "/index.html";
+  } else if (pathname.endsWith("/")) {
+    pathname += "index.html";
+  }
+
+  const sanitizedPath = pathname.replace(/^\/+/, "");
+  const absolutePath = path.normalize(path.join(APP_ROOT, sanitizedPath));
+  const relativePath = path.relative(APP_ROOT, absolutePath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return absolutePath;
+}
+
+function registerAppProtocol() {
+  protocol.handle(APP_SCHEME, async (request) => {
+    const requestUrl = new URL(request.url);
+    const assetPath = resolveAssetPath(requestUrl);
+
+    if (!assetPath) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const fileUrl = pathToFileURL(assetPath);
+    fileUrl.search = requestUrl.search;
+
+    try {
+      return await net.fetch(fileUrl);
+    } catch {
+      return new Response("Not Found", { status: 404 });
+    }
+  });
+}
+
+function registerPermissionHandler() {
+  session.defaultSession.setPermissionRequestHandler(
+    (webContents, permission, callback, details) => {
+      const requestingUrl = details?.requestingUrl ?? webContents.getURL();
+      const originProtocol = requestingUrl ? new URL(requestingUrl).protocol : null;
+      const isAllowed = originProtocol === `${APP_SCHEME}:` && permission === "media";
+
+      callback(isAllowed);
+    }
+  );
 }
 
 function createWindow() {
@@ -38,10 +116,12 @@ function createWindow() {
     }
   });
 
-  mainWindow.loadFile(APP_INDEX_HTML);
+  mainWindow.loadURL(APP_ENTRYPOINT);
 }
 
 app.whenReady().then(() => {
+  registerAppProtocol();
+  registerPermissionHandler();
   createWindow();
 
   app.on("activate", () => {


### PR DESCRIPTION
### Motivation
- Avoid serving UI over `file://` and provide a secure `app://` context for bundled desktop assets.
- Serve `desktop/app/` assets reliably while preventing path traversal and preserving relative navigation.
- Restrict powerful permissions such as camera/microphone to only trusted origins.
- Keep existing external link behavior (open in default browser) unchanged.

### Description
- Register the `app` scheme as privileged with `protocol.registerSchemesAsPrivileged` and import `protocol`, `session`, and `net` to support secure fetch handling.
- Add a `protocol.handle('app', ...)` handler that resolves requests to `desktop/app/`, enforces traversal protection, treats directory paths as `index.html`, and returns file bytes via `net.fetch` and `pathToFileURL`.
- Change the window entrypoint to `app://bundle/index.html` and keep external link handling via `shell.openExternal` intact.
- Add a permission handler with `session.defaultSession.setPermissionRequestHandler` that allows only the `media` permission when the request originates from the `app://` origin and denies other requests.

### Testing
- Ran `npm run sync:web` which completed successfully and copied assets into `desktop/app`.
- No automated unit tests exist for the Electron runtime changes in this patch, so no additional CI tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c63ece3a483338e028831e3d8e6fb)