### PR TITLE
Add tag-triggered Windows build workflow and upload .exe artifact

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -2,8 +2,8 @@ name: Desktop Windows Build
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
   workflow_dispatch:
 
 jobs:
@@ -20,13 +20,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "lts/*"
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
 
       - name: Install dependencies
-        run: npm install
-
-      - name: Sync web assets
-        run: npm run sync-web
+        run: npm ci
 
       - name: Build Windows installer
         run: npm run dist:win
@@ -34,6 +33,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-dist-windows
-          path: desktop/dist/*
+          name: windows-installer
+          path: desktop/dist/*.exe
           if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Enable CI to produce Windows NSIS installer and make the generated `.exe` available as an artifact.
- Trigger builds for release tags and manual runs to match release flow requirements.
- Improve build stability and speed by using Node.js LTS and enabling npm cache.

### Description
- Change workflow triggers to `push` tags matching `v*` and `workflow_dispatch` in `.github/workflows/desktop-windows.yml`.
- Use `actions/setup-node` with `node-version: "lts/*"`, `cache: npm`, and `cache-dependency-path: desktop/package-lock.json`.
- Replace `npm install` with `npm ci` and remove the `npm run sync-web` step, then run `npm run dist:win` inside `desktop` working directory.
- Upload the produced installer as an artifact named `windows-installer` with path `desktop/dist/*.exe` using `actions/upload-artifact`.

### Testing
- No automated tests were run because this change is a workflow definition update only.
- The workflow file was validated and updated in the repository, but the GitHub Actions run has not been executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c7a9c5018833381aafcd02fc30598)