### PR TITLE
Add SIRIUS RL governance docs, issue/PR templates, and Codex prompts

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/rl_eval.yml
+++ b/.github/ISSUE_TEMPLATE/rl_eval.yml
@@ -1,0 +1,87 @@
+name: RL Evaluation / Tests (SIRIUS)
+description: EVAL（bench / pytest / CIゲート）系のIssue
+title: "[S-EVAL][M?] <short summary>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **評価・テスト・CIゲート** 用のIssueフォームです。  
+        重要: テストは **非flaky**（seed固定/期待値評価/決定論環境）を優先してください。
+
+  - type: dropdown
+    id: mission
+    attributes:
+      label: Mission
+      options:
+        - m1（bandit）
+        - m2（mdp/gridworld + dp）
+        - m3（td/q-learning）
+        - common
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目的 / Goal（ゲート条件）
+      placeholder: |
+        - [ ] CIで安定して通る
+        - [ ] 失敗時にデバッグしやすい（数値が出る）
+    validations:
+      required: true
+
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Metrics / Thresholds（数値・閾値）
+      description: 例: regret ratio / success_rate >= 0.8 など
+      placeholder: |
+        - success_rate >= 0.8
+        - eps_regret <= baseline_regret * 0.75
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context（対象ファイル/パラメータ/非flaky設計）
+      placeholder: |
+        Target files:
+        - tests/...
+        - sirius_rl/...
+        Params:
+        - probs=[0.1,0.2,0.8], T=500, seeds=10
+        Notes:
+        - regretは期待値で計算する
+    validations:
+      required: true
+
+  - type: textarea
+    id: aj
+    attributes:
+      label: A_j（影響obligation）
+      description: 1行1IDで列挙（例: eval.m3.td.success_rate.ge_0_8）
+      placeholder: |
+        - eval.m3.td.test.non_flaky_gate
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification（実行コマンド）
+      placeholder: |
+        - pytest -q
+        - pytest -q tests/test_bandit_agents.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: codex_prompt
+    attributes:
+      label: Codex prompt（そのままCodexに貼る用・任意）
+      description: 「対象ファイル」「設計（非flaky）」「assert条件」「実行コマンド」を短く。
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/rl_impl.yml
+++ b/.github/ISSUE_TEMPLATE/rl_impl.yml
@@ -1,0 +1,107 @@
+name: RL Implementation (SIRIUS)
+description: CUR/ENV/GP/OBS/BIZ など「実装・運用・ドキュメント」系のIssue
+title: "[S-?][M?] <short summary>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **SIRIUS RL** 用の実装Issueフォームです。  
+        重要: **A_j（影響obligation）** を必ず入れてください（PRでも必須）。
+        
+        参考: `docs/rl/obligations.md`, `docs/rl/pass_criteria.md`
+
+  - type: dropdown
+    id: s_field
+    attributes:
+      label: S（領域）
+      options:
+        - cur（カリキュラム/アルゴリズム実装）
+        - env（環境）
+        - gp（導線/運用/再現性）
+        - obs（観測/可視化 ※CI外が基本）
+        - biz（合格定義/価値最大化）
+        - eval（評価/テスト）※評価は rl_eval フォーム推奨
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mission
+    attributes:
+      label: Mission
+      options:
+        - common
+        - m1（bandit）
+        - m2（mdp/gridworld + dp）
+        - m3（td/q-learning）
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options:
+        - feature
+        - docs
+        - ops
+        - analysis（CI外）
+        - refactor
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目的 / Goal（何ができればOKか）
+      description: ユーザー価値とDone条件を短く。チェックリスト歓迎。
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context（関連ファイル/参考実装/制約）
+      placeholder: |
+        Relevant paths:
+        - sirius_rl/...
+        Reference:
+        - ...
+        Constraints:
+        - No new deps
+        - No print/log
+    validations:
+      required: true
+
+  - type: textarea
+    id: aj
+    attributes:
+      label: A_j（影響obligation）
+      description: 1行1IDで列挙（例: eval.m1.bandit.bench.regret_mean）
+      placeholder: |
+        - gp.common.repro.seed_fixed
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification（再現/確認/テスト）
+      description: 最短のコマンドを列挙（CIを重くしない）。
+      placeholder: |
+        - pytest -q
+        - python -m ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: codex_prompt
+    attributes:
+      label: Codex prompt（そのままCodexに貼る用・任意）
+      description: 「短く」「パス明示」「検証手順」だけを書く（Less is more）。
+      render: text
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,27 @@
 ## Summary
-- 変更内容を1〜3行で
+- What changed / why?
 
-## Time / Trials / Outcome
-- Time: XX min / Trials: N
-- Outcome: Pass | Fail | Partial
+## Reproducibility
+- Seed:
+- Algorithm:
+- Steps (horizon/episodes/T/max_steps etc):
 
-## A_j (Impacted obligations)
-- 例: gp.01, eval.02, env.00
-- 影響なしの場合は `A_j: none`
+## Experiment log (short)
+- Time Spent (min):
+- Trials (seeds count / runs):
+- Outcome: Pass / Fail
+- Notes:
 
-## Test Evidence
-- 実行コマンドと結果ログ（抜粋可）
-- 例: `pytest tests/test_smoke.py` / `ruff .`
+## A_j（影響obligation）
+<!-- 1行1IDで列挙 -->
+- 
 
-## Impact / Risk
-- 影響範囲（UI / CI / env / docs など）
-- リスクと緩和策（flake防止、seed固定、CI時間 など）
+## Verification
+<!-- 実行したコマンドと結果 -->
+- [ ] `pytest -q` (or minimal relevant tests)
+
+## Checklist
+- [ ] Diff is minimal and follows existing conventions
+- [ ] No print/debug logs added
+- [ ] RNG is reproducible (seed-fixed) where applicable
+- [ ] CI should remain fast / non-flaky

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md (SIRIUS RL)
+
+このリポジトリで Codex が作業するときの共通ルールです。**差分は最小**、**CI は非flaky**、**再現性（seed 固定）**を最優先にします。
+
+## ゴール
+- Mission 1: Bandit（agent 実装 + bench + 非flaky テスト）
+- Mission 2: GridWorld（決定論） + DP（value/policy iteration） + テスト
+- Mission 3: TD（Q-learning） + 評価（success_rate） + 非flaky テスト
+- すべての PR は「A_j（影響 obligation）」を明記してレビュー可能にする。
+
+## 作業規約
+- **最小差分**: 既存設計・命名・フォルダ構成に合わせる。不要なリファクタ禁止。
+- **非flaky**: テストは確率に依存しない/依存を最小化する（期待値・固定 seed・決定論環境）。
+- **seed 固定**:
+  - 乱数はグローバル状態に依存しない（`random` のグローバル、`np.random` のグローバルは避ける）。
+  - 必要なら `numpy.random.Generator` を内部に保持し、`seed` から生成する。
+  - tie-break（同値 max の選択）は rng で行い、seed で再現できるようにする。
+- **CI を軽く**: episode/horizon/seeds を必要最小に。重い可視化は CI 外（scripts 等）へ。
+- **ログ禁止**: print / debug ログを追加しない（失敗時はテスト assert メッセージで分かるようにする）。
+- **型と docstring**: public 関数/クラスには type hints と短い docstring を付ける。
+
+## 評価の原則（重要）
+- Bandit の regret は CI 安定のため **期待 regret**（`max_p - probs[action_t]` の和）を推奨。
+- Q-learning の合否は deterministic GridWorld 上で success_rate を見る（確率環境にしない）。
+
+## 変更後の基本チェック
+- 可能なら `pytest -q`（または最小の関連テスト）を実行し、失敗しないことを確認する。
+- PR には以下を必ず記載する:
+  - Seed / Algorithm / Steps
+  - Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes
+  - A_j（影響 obligation）: 1 行 1 ID で列挙

--- a/codex_prompts/sirius_eval_gate.md
+++ b/codex_prompts/sirius_eval_gate.md
@@ -1,0 +1,25 @@
+# SIRIUS RL — Evaluation / Gate Prompt
+
+Use this prompt for adding or hardening evaluation/CI gates. Focus on deterministic, seed-fixed checks.
+
+```
+You are working on the SIRIUS RL repository.
+Follow AGENTS.md (seed-fixed RNG, deterministic env, minimal diff, no logs).
+
+Mission: <m1/m2/m3>
+Gate objective:
+- <metric and threshold, e.g., success_rate >= 0.8 or expected_regret ratio>
+
+Context:
+- Target tests/bench files: <tests/... | sirius_rl/eval/...>
+- Env/setup params: <probs/horizon/episodes/seeds/tol>
+- Expectation: deterministic, non-flaky, short runtime
+
+A_j (impacted obligations):
+- <eval.* or biz.* IDs from docs/rl/obligations.md>
+
+Verification (must be CI-friendly):
+- pytest -q <narrowest test path>
+
+Report the final assertions and any seed values used.
+```

--- a/codex_prompts/sirius_task.md
+++ b/codex_prompts/sirius_task.md
@@ -1,0 +1,30 @@
+# SIRIUS RL — Task Prompt (Implementation)
+
+Use this prompt when sending implementation work to Codex. Keep it short and focused on paths, requirements, and verification.
+
+```
+You are working on the SIRIUS RL repository.
+Follow AGENTS.md (minimal diff, seed-fixed RNG, non-flaky tests, no print/log).
+
+Mission: <m1/m2/m3/common>
+Scope (S column): <gp/cur/env/obs/biz>
+Goal:
+- <bullet list of done conditions>
+
+Relevant paths:
+- <sirius_rl/... or docs/...>
+
+Requirements / constraints:
+- No new dependencies
+- Deterministic env (if applicable)
+- RNG = local Generator seeded via input
+- No debug prints; keep CI fast
+
+A_j (impacted obligations):
+- <id from docs/rl/obligations.md>
+
+Verification (fastest reproducible):
+- pytest -q <tests/...>  # keep short
+
+Return only the code diff with minimal commentary.
+```

--- a/docs/rl/obligations.md
+++ b/docs/rl/obligations.md
@@ -1,0 +1,46 @@
+# obligations (SIRIUS RL)
+
+このページは **「守るべき約束（obligation）」** を ID で管理するための一覧です。Issue / PR では影響した obligation を **A_j** に列挙してください。
+
+## ID 体系
+- 形式: `<prefix>.<mission>.<domain>.<name>`
+- prefix:
+  - `biz` = 合格定義・価値最大化（Gate/基準の固定）
+  - `gp` = 導線・運用・再現性（テンプレ/ラベル/Projects/再現）
+  - `env` = 環境・世界・仕様（MDP/遷移/報酬）
+  - `cur` = カリキュラム・アルゴリズム実装（Agents/DP/TD）
+  - `eval` = 評価・テスト・CI ゲート（bench/test）
+  - `obs` = 観測・ログ・可視化（CI 外の学習支援）
+
+## 共通（全ミッション）
+- `gp.common.repro.seed_fixed` — 乱数はローカル RNG（`numpy.random.Generator` 等）で seed 固定し、グローバル状態に依存しない。
+- `gp.common.ops.minimal_diff` — 既存設計/命名/構造に沿い、不要なリファクタや大規模変更を避ける。
+- `gp.common.ops.no_logs` — ライブラリコードやテストに print/debug ログを追加しない。
+- `gp.common.ops.fast_ci` — CI 時間を短く、期待値評価や決定論を優先して非 flaky にする。
+- `biz.common.review.a_j_required` — すべての Issue/PR で A_j（影響 obligation）を明記する。
+- `obs.common.viz.ci_opt_out` — 可視化は `scripts/` 側など CI 外に置き、依存増・時間増を避ける。
+
+## Mission 1 (Bandit)
+- `env.m1.bandit.arms.probs_static` — アーム確率は固定で決定論的に扱い、ベンチマークが再現できること。
+- `cur.m1.bandit.agent.eps_greedy` — ε-greedy などの agent は seed 入力を受け取り、rng を内部保持する。
+- `cur.m1.bandit.agent.ucb` — UCB 系の実装も同様に再現性を維持する。
+- `eval.m1.bandit.bench.expected_regret` — regret は `max_p - probs[action_t]` の期待 regret を用いて分散を抑える。
+- `eval.m1.bandit.test.non_flaky_gate` — horizon/episodes/seeds は最小構成で安定し、テストが非 flaky であること。
+
+## Mission 2 (MDP / DP)
+- `env.m2.gridworld.deterministic` — GridWorld は決定論的な遷移と報酬を持つ（壁はその場に留まる等）。
+- `env.m2.gridworld.model_fn` — `env.model()` などの API で遷移確率/報酬を取得できる。
+- `cur.m2.dp.value_iteration` — Value Iteration の実装は小規模 Grid で収束し、seed 非依存。
+- `cur.m2.dp.policy_iteration` — Policy Iteration も決定論環境で期待通りの方策に収束する。
+- `eval.m2.dp.test.expected_policy` — 期待される価値/方策をテストで検証し、確率的要素を排除する。
+
+## Mission 3 (TD / Q-learning)
+- `env.m3.gridworld.deterministic` — TD でも確率的要素を入れず、決定論 GridWorld を使う。
+- `cur.m3.td.q_learning` — Q-learning は epsilon 制御や学習率が seed で再現可能、RNG はローカル管理。
+- `eval.m3.td.success_rate_gate` — success_rate >= 0.8 を合格基準とし、episodes/seeds は最小で安定化。
+- `eval.m3.td.test.non_flaky_gate` — テストは固定 seed + 平均化で非 flaky、実行時間を短く保つ。
+
+## 追加・更新の扱い
+- obligation が未定義なら、本ファイルに ID 体系を守って追加する。
+- 既存の obligation に影響した場合、PR の A_j に該当 ID を列挙する。
+- 不要になった obligation を削除する際は、根拠と影響範囲を説明する。

--- a/docs/rl/pass_criteria.md
+++ b/docs/rl/pass_criteria.md
@@ -1,0 +1,34 @@
+# pass criteria (SIRIUS RL)
+
+合格基準（CI ゲート）を明文化します。実装・テストはこの基準に合わせ、**非 flaky（seed 固定 / 決定論 / 期待値評価）** を最優先にします。
+
+## 共通（CI 設計の原則）
+- seed を固定し、グローバル RNG に依存しない。
+- ratio / 期待値を優先して分散を下げる（例: regret は期待 regret）。
+- 環境は可能な限り決定論的にし、確率的な遷移を CI に含めない。
+- episodes / horizon / seeds は必要最小限で短時間に収束する構成を選ぶ。
+- ログや可視化は CI から外す（scripts や notebooks 側に寄せる）。
+
+## Mission 1 (Bandit) — regret gate
+- metric: 期待 regret = `sum_t (max_p - probs[action_t])`
+- thresholds:
+  - `eps_regret <= baseline_regret * 0.75` を目安に改善
+  - `ucb_regret <= eps_regret * 0.95` で上位手法の優位を確認
+- setup: 少数のアーム（例: 3〜5）、短い horizon で安定する seed を使用
+- notes: RNG を内部保持し tie-break も seed で再現する
+
+## Mission 2 (MDP / DP) — expected policy gate
+- env: 決定論 GridWorld（壁はその場に留まる、ゴールで終了）
+- metrics:
+  - 価値関数が閾値以内で収束（例: `|V_k - V_{k-1}| < tol`）
+  - 方策が期待どおり（ゴールへの最短経路、壁回避）
+- setup: 小規模 Grid（3x3〜5x5）で iteration 回数を抑え、seed 非依存
+- notes: 遷移/報酬は `env.model()` 等で取得できることを確認
+
+## Mission 3 (TD / Q-learning) — success_rate gate
+- metric: success_rate >= 0.8
+- setup:
+  - episodes: 500〜2000 の範囲で最小の安定点を選択
+  - seeds: 3〜5 で平均化し、固定 seed を明示
+  - epsilon/alpha/gamma は既存設定に合わせ、rng はローカル管理
+- notes: 確率的遷移を入れず、決定論 GridWorld 上で学習を評価する


### PR DESCRIPTION
### Motivation
- Consolidate course-specific governance so Codex can be used directly with consistent expectations and minimal per-task prompts.
- Enforce reproducibility and non-flaky CI by prescribing seed-fixed RNG usage and minimal-diff changes.
- Make `A_j` (impacted obligation) mandatory in Issue/PR workflows to improve traceability of changes.
- Provide compact Codex prompt skeletons to standardize and simplify automated agent input for SIRIUS missions.

### Description
- Added `AGENTS.md` containing repository-wide guardrails (seed handling, no logs, minimal diffs, CI guidance).
- Added `docs/rl/obligations.md` and `docs/rl/pass_criteria.md` to enumerate obligation IDs and concrete pass criteria for M1/M2/M3.
- Added GitHub Issue Forms: `.github/ISSUE_TEMPLATE/rl_impl.yml`, `.github/ISSUE_TEMPLATE/rl_eval.yml`, and `.github/ISSUE_TEMPLATE/config.yml` to require `A_j` and verification steps.
- Updated PR template `.github/pull_request_template.md` and added Codex prompt templates under `codex_prompts/` to support direct Codex workflows.

### Testing
- No automated tests were run because this change only adds documentation and repository templates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6b29c39c8333b199539a4d3262ea)