### PR TITLE
Sync SIRIUS RL docs and Codex prompt templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: true
+contact_links:
+  - name: SIRIUS RL - obligations / pass criteria
+    url: https://example.com/CHANGE-ME
+    about: "A_j（影響obligation）と合格基準（CI非flaky）を確認してからIssueを作成してください。"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,26 @@
 # AGENTS.md (SIRIUS RL)
 
-このリポジトリで Codex が作業するときの共通ルールです。**差分は最小**、**CI は非flaky**、**再現性（seed 固定）**を最優先にします。
+このリポジトリで Codex が作業するときの共通ルールです。**差分は最小**、**CIは非flaky**、**再現性（seed固定）**を最優先にします。
 
 ## ゴール
-- Mission 1: Bandit（agent 実装 + bench + 非flaky テスト）
+- Mission 1: Bandit（agent 実装 + bench + 非flakyテスト）
 - Mission 2: GridWorld（決定論） + DP（value/policy iteration） + テスト
-- Mission 3: TD（Q-learning） + 評価（success_rate） + 非flaky テスト
-- すべての PR は「A_j（影響 obligation）」を明記してレビュー可能にする。
+- Mission 3: TD（Q-learning） + 評価（success_rate） + 非flakyテスト
+- すべての PR は「A_j（影響obligation）」を明記してレビュー可能にする。
 
 ## 作業規約
 - **最小差分**: 既存設計・命名・フォルダ構成に合わせる。不要なリファクタ禁止。
-- **非flaky**: テストは確率に依存しない/依存を最小化する（期待値・固定 seed・決定論環境）。
-- **seed 固定**:
+- **非flaky**: テストは確率に依存しない/依存を最小化する（期待値・固定seed・決定論環境）。
+- **seed固定**:
   - 乱数はグローバル状態に依存しない（`random` のグローバル、`np.random` のグローバルは避ける）。
   - 必要なら `numpy.random.Generator` を内部に保持し、`seed` から生成する。
-  - tie-break（同値 max の選択）は rng で行い、seed で再現できるようにする。
-- **CI を軽く**: episode/horizon/seeds を必要最小に。重い可視化は CI 外（scripts 等）へ。
+  - tie-break（同値maxの選択）は rng で行い、seedで再現できるようにする。
+- **CIを軽く**: episode/horizon/seeds を必要最小に。重い可視化は CI 外（scripts 等）へ。
 - **ログ禁止**: print / debug ログを追加しない（失敗時はテスト assert メッセージで分かるようにする）。
-- **型と docstring**: public 関数/クラスには type hints と短い docstring を付ける。
+- **型とdocstring**: public関数/クラスには type hints と短い docstring を付ける。
 
 ## 評価の原則（重要）
-- Bandit の regret は CI 安定のため **期待 regret**（`max_p - probs[action_t]` の和）を推奨。
+- Bandit の regret は CI安定のため **期待regret**（`max_p - probs[action_t]` の和）を推奨。
 - Q-learning の合否は deterministic GridWorld 上で success_rate を見る（確率環境にしない）。
 
 ## 変更後の基本チェック
@@ -28,4 +28,4 @@
 - PR には以下を必ず記載する:
   - Seed / Algorithm / Steps
   - Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes
-  - A_j（影響 obligation）: 1 行 1 ID で列挙
+  - A_j（影響obligation）: 1行1IDで列挙

--- a/codex_prompts/sirius_eval_gate.md
+++ b/codex_prompts/sirius_eval_gate.md
@@ -1,25 +1,26 @@
-# SIRIUS RL — Evaluation / Gate Prompt
+---
+description: SIRIUS RL: Codex prompt for evaluation/tests (non-flaky gate)
+argument-hint: TITLE="..." PATHS="..." MISSION="m1|m2|m3" AJ="id1,id2" TEST="pytest -q tests/..."
+---
 
-Use this prompt for adding or hardening evaluation/CI gates. Focus on deterministic, seed-fixed checks.
+Title: $TITLE
 
-```
-You are working on the SIRIUS RL repository.
-Follow AGENTS.md (seed-fixed RNG, deterministic env, minimal diff, no logs).
-
-Mission: <m1/m2/m3>
-Gate objective:
-- <metric and threshold, e.g., success_rate >= 0.8 or expected_regret ratio>
+Goal:
+- Implement/adjust evaluation + tests so CI gate is stable (non-flaky).
 
 Context:
-- Target tests/bench files: <tests/... | sirius_rl/eval/...>
-- Env/setup params: <probs/horizon/episodes/seeds/tol>
-- Expectation: deterministic, non-flaky, short runtime
+- Mission: $MISSION
+- Target files: $PATHS
+- Non-flaky rules: seed-fixed, deterministic env, prefer expected metrics (e.g., expected regret)
 
-A_j (impacted obligations):
-- <eval.* or biz.* IDs from docs/rl/obligations.md>
+A_j (affected obligations):
+- $AJ
 
-Verification (must be CI-friendly):
-- pytest -q <narrowest test path>
+Requirements:
+- [ ] Define metrics + thresholds explicitly (ratio/absolute)
+- [ ] Failure message prints key numbers for debugging
+- [ ] Keep runtime low (CI-friendly)
 
-Report the final assertions and any seed values used.
-```
+Verification:
+- Run: $TEST
+- Expected: test passes reliably with fixed seeds.

--- a/codex_prompts/sirius_task.md
+++ b/codex_prompts/sirius_task.md
@@ -1,30 +1,31 @@
-# SIRIUS RL — Task Prompt (Implementation)
+---
+description: SIRIUS RL: produce a Codex-ready task prompt (minimal, issue-style)
+argument-hint: TITLE="..." PATHS="..." MISSION="m1|m2|m3|common" AJ="id1,id2" TESTS="pytest -q ..."
+---
 
-Use this prompt when sending implementation work to Codex. Keep it short and focused on paths, requirements, and verification.
+Title: $TITLE
 
-```
-You are working on the SIRIUS RL repository.
-Follow AGENTS.md (minimal diff, seed-fixed RNG, non-flaky tests, no print/log).
-
-Mission: <m1/m2/m3/common>
-Scope (S column): <gp/cur/env/obs/biz>
 Goal:
-- <bullet list of done conditions>
+- <What must be true when done?>
 
-Relevant paths:
-- <sirius_rl/... or docs/...>
+Context:
+- Mission: $MISSION
+- Relevant paths: $PATHS
+- Reference implementation/pattern: <optional>
+- Constraints: no new deps, no print/log, keep diffs minimal, keep CI fast & non-flaky
 
-Requirements / constraints:
-- No new dependencies
-- Deterministic env (if applicable)
-- RNG = local Generator seeded via input
-- No debug prints; keep CI fast
+A_j (affected obligations):
+- $AJ
 
-A_j (impacted obligations):
-- <id from docs/rl/obligations.md>
+Requirements:
+- [ ] <bullet requirements>
 
-Verification (fastest reproducible):
-- pytest -q <tests/...>  # keep short
+Verification:
+- Run:
+  - $TESTS
+- Acceptance criteria:
+  - <observable expected outcomes>
 
-Return only the code diff with minimal commentary.
-```
+Deliverable:
+- Implement + adjust/add minimal tests/docs if needed.
+- Report commands you ran and outcomes (brief).

--- a/docs/rl/obligations.md
+++ b/docs/rl/obligations.md
@@ -1,46 +1,84 @@
-# obligations (SIRIUS RL)
+# obligations (A_j) 一覧
 
-このページは **「守るべき約束（obligation）」** を ID で管理するための一覧です。Issue / PR では影響した obligation を **A_j** に列挙してください。
+このリポジトリでは、Issue/PRごとに **A_j（影響obligation）** を列挙して「変更が何に効くか」を追跡します。
 
-## ID 体系
-- 形式: `<prefix>.<mission>.<domain>.<name>`
-- prefix:
-  - `biz` = 合格定義・価値最大化（Gate/基準の固定）
-  - `gp` = 導線・運用・再現性（テンプレ/ラベル/Projects/再現）
-  - `env` = 環境・世界・仕様（MDP/遷移/報酬）
-  - `cur` = カリキュラム・アルゴリズム実装（Agents/DP/TD）
-  - `eval` = 評価・テスト・CI ゲート（bench/test）
-  - `obs` = 観測・ログ・可視化（CI 外の学習支援）
+## ID体系
+- 形式: `S.mission.domain...`（ドット区切り）
+- `S` は次のいずれか: `biz` / `gp` / `env` / `cur` / `eval` / `obs`
+- `mission` は次のいずれか: `common` / `m1` / `m2` / `m3`
+- 末尾は metric / gate / schema など、影響対象を表す（命名は固定し、後方互換を優先）
 
-## 共通（全ミッション）
-- `gp.common.repro.seed_fixed` — 乱数はローカル RNG（`numpy.random.Generator` 等）で seed 固定し、グローバル状態に依存しない。
-- `gp.common.ops.minimal_diff` — 既存設計/命名/構造に沿い、不要なリファクタや大規模変更を避ける。
-- `gp.common.ops.no_logs` — ライブラリコードやテストに print/debug ログを追加しない。
-- `gp.common.ops.fast_ci` — CI 時間を短く、期待値評価や決定論を優先して非 flaky にする。
-- `biz.common.review.a_j_required` — すべての Issue/PR で A_j（影響 obligation）を明記する。
-- `obs.common.viz.ci_opt_out` — 可視化は `scripts/` 側など CI 外に置き、依存増・時間増を避ける。
+## 一覧
+### COMMON（運用）
+#### biz
+- `biz.common.pass_criteria.definition`
 
-## Mission 1 (Bandit)
-- `env.m1.bandit.arms.probs_static` — アーム確率は固定で決定論的に扱い、ベンチマークが再現できること。
-- `cur.m1.bandit.agent.eps_greedy` — ε-greedy などの agent は seed 入力を受け取り、rng を内部保持する。
-- `cur.m1.bandit.agent.ucb` — UCB 系の実装も同様に再現性を維持する。
-- `eval.m1.bandit.bench.expected_regret` — regret は `max_p - probs[action_t]` の期待 regret を用いて分散を抑える。
-- `eval.m1.bandit.test.non_flaky_gate` — horizon/episodes/seeds は最小構成で安定し、テストが非 flaky であること。
+#### gp
+- `gp.common.issue_form.fields`
+- `gp.common.labels.s_field_sync`
+- `gp.common.pr_template.aj_required`
+- `gp.common.pr_template.reproducibility`
+- `gp.common.projects.status_workflow`
+- `gp.common.repro.seed_fixed`
 
-## Mission 2 (MDP / DP)
-- `env.m2.gridworld.deterministic` — GridWorld は決定論的な遷移と報酬を持つ（壁はその場に留まる等）。
-- `env.m2.gridworld.model_fn` — `env.model()` などの API で遷移確率/報酬を取得できる。
-- `cur.m2.dp.value_iteration` — Value Iteration の実装は小規模 Grid で収束し、seed 非依存。
-- `cur.m2.dp.policy_iteration` — Policy Iteration も決定論環境で期待通りの方策に収束する。
-- `eval.m2.dp.test.expected_policy` — 期待される価値/方策をテストで検証し、確率的要素を排除する。
+### M1（Bandit）
+#### biz
+- `biz.m1.bandit.pass_criteria.regret_ratio`
 
-## Mission 3 (TD / Q-learning)
-- `env.m3.gridworld.deterministic` — TD でも確率的要素を入れず、決定論 GridWorld を使う。
-- `cur.m3.td.q_learning` — Q-learning は epsilon 制御や学習率が seed で再現可能、RNG はローカル管理。
-- `eval.m3.td.success_rate_gate` — success_rate >= 0.8 を合格基準とし、episodes/seeds は最小で安定化。
-- `eval.m3.td.test.non_flaky_gate` — テストは固定 seed + 平均化で非 flaky、実行時間を短く保つ。
+#### gp
+- `gp.m1.bandit.learning_feedback`
 
-## 追加・更新の扱い
-- obligation が未定義なら、本ファイルに ID 体系を守って追加する。
-- 既存の obligation に影響した場合、PR の A_j に該当 ID を列挙する。
-- 不要になった obligation を削除する際は、根拠と影響範囲を説明する。
+#### cur
+- `cur.m1.bandit.agent.eps_greedy`
+- `cur.m1.bandit.agent.thompson_bernoulli`
+- `cur.m1.bandit.agent.ucb1`
+
+#### eval
+- `eval.m1.bandit.bench.regret_mean`
+- `eval.m1.bandit.bench.reward_mean`
+- `eval.m1.bandit.bench.seed_aggregation`
+- `eval.m1.bandit.pass_thresholds`
+- `eval.m1.bandit.test.baseline_compare`
+- `eval.m1.bandit.test.non_flaky_gate`
+
+#### obs
+- `obs.m1.bandit.regret_curve`
+
+### M2（MDP/GridWorld + DP）
+#### gp
+- `gp.m2.docs.mdp_table`
+- `gp.m2.docs.repro_steps`
+
+#### env
+- `env.m2.gridworld.action.up_down_left_right`
+- `env.m2.gridworld.model.transition_table`
+- `env.m2.gridworld.transition.deterministic`
+- `env.m2.gridworld.wall_stay`
+
+#### cur
+- `cur.m2.dp.policy_iteration`
+- `cur.m2.dp.value_iteration`
+
+#### eval
+- `eval.m2.dp.policy_expected`
+- `eval.m2.dp.test.expected_policy`
+
+### M3（TD/Q-learning）
+#### biz
+- `biz.m3.qlearn.pass_criteria.success_rate`
+
+#### cur
+- `cur.m3.td.greedy_policy`
+- `cur.m3.td.q_learning`
+
+#### eval
+- `eval.m3.td.eval_runner`
+- `eval.m3.td.pass_thresholds`
+- `eval.m3.td.success_rate`
+- `eval.m3.td.success_rate.ge_0_8`
+- `eval.m3.td.test.non_flaky_gate`
+
+#### obs
+- `obs.m3.td.learning_curve`
+- `obs.m3.td.metrics_schema_fixed`
+- `obs.m3.td.reproducible_plot`

--- a/docs/rl/pass_criteria.md
+++ b/docs/rl/pass_criteria.md
@@ -1,34 +1,63 @@
-# pass criteria (SIRIUS RL)
+# Pass criteria（合格基準）とCI非flaky化
 
-合格基準（CI ゲート）を明文化します。実装・テストはこの基準に合わせ、**非 flaky（seed 固定 / 決定論 / 期待値評価）** を最優先にします。
+このリポジトリの合格は「CIのゲートを安定して通ること」です。確率要素は**seed固定**と**期待値評価**で吸収し、テストが揺れない設計にします。
 
-## 共通（CI 設計の原則）
-- seed を固定し、グローバル RNG に依存しない。
-- ratio / 期待値を優先して分散を下げる（例: regret は期待 regret）。
-- 環境は可能な限り決定論的にし、確率的な遷移を CI に含めない。
-- episodes / horizon / seeds は必要最小限で短時間に収束する構成を選ぶ。
-- ログや可視化は CI から外す（scripts や notebooks 側に寄せる）。
+## 共通原則（Non-flaky）
+- **seed固定**: 乱数は `seed` から生成したrngに閉じ込める（グローバルrngを使わない）。
+- **決定論の優先**: 環境は可能な限り決定論（GridWorldは決定論）。
+- **期待値で評価**: Bandit regret はサンプル報酬ではなく「期待regret」を優先する。
+- **CIを軽く**: horizon/episodes/seeds は最小構成で安定する値にする（テスト側で固定）。
 
-## Mission 1 (Bandit) — regret gate
-- metric: 期待 regret = `sum_t (max_p - probs[action_t])`
-- thresholds:
-  - `eps_regret <= baseline_regret * 0.75` を目安に改善
-  - `ucb_regret <= eps_regret * 0.95` で上位手法の優位を確認
-- setup: 少数のアーム（例: 3〜5）、短い horizon で安定する seed を使用
-- notes: RNG を内部保持し tie-break も seed で再現する
+---
 
-## Mission 2 (MDP / DP) — expected policy gate
-- env: 決定論 GridWorld（壁はその場に留まる、ゴールで終了）
-- metrics:
-  - 価値関数が閾値以内で収束（例: `|V_k - V_{k-1}| < tol`）
-  - 方策が期待どおり（ゴールへの最短経路、壁回避）
-- setup: 小規模 Grid（3x3〜5x5）で iteration 回数を抑え、seed 非依存
-- notes: 遷移/報酬は `env.model()` 等で取得できることを確認
+## Mission 1（Bandit）
+### 目的
+- Bandit agents（EpsilonGreedy/UCB1/Thompson Sampling）を実装し、ベンチ関数＋pytestで安定に比較できるようにする。
 
-## Mission 3 (TD / Q-learning) — success_rate gate
-- metric: success_rate >= 0.8
-- setup:
-  - episodes: 500〜2000 の範囲で最小の安定点を選択
-  - seeds: 3〜5 で平均化し、固定 seed を明示
-  - epsilon/alpha/gamma は既存設定に合わせ、rng はローカル管理
-- notes: 確率的遷移を入れず、決定論 GridWorld 上で学習を評価する
+### 合格基準（推奨ゲート）
+- `bandit_bench` が複数seedで `mean_reward` / `mean_regret` を返せる。
+- pytestで「random baseline より regret が十分小さい」ことを**相対**で判定する。
+  - 例（推奨）:
+    - `eps_regret <= baseline_regret * 0.75`
+    - `ucb_regret <= eps_regret * 0.95`
+    - `ts_regret` は baseline より良い、または eps より良い等の閾値を設定
+
+### テスト安定化の推奨設定
+- `probs = [0.1, 0.2, 0.8]` のように差が大きいもの
+- `T=300〜800`、`seeds=5〜10` を目安に「最小で安定」する値に調整
+- regret は **期待regret**:
+  - `regret = sum_t (max(probs) - probs[action_t])`
+  - ※サンプルrewardで計算すると分散が大きくなりflakyになりやすい
+
+---
+
+## Mission 2（MDP/GridWorld + DP）
+### 目的
+- 決定論GridWorld + `env.model()`（遷移表）を土台に、DP（価値反復/方策反復）を実装し、最適方策がテストで固定できるようにする。
+
+### 合格基準（推奨ゲート）
+- GridWorldが決定論である（壁はその場・遷移が固定）。
+- `value_iteration` / `policy_iteration` が `env.model()` を使って最適方策（または価値）を導出できる。
+- 小規模Gridで「期待どおりの最適方策」になることをpytestで検証できる。
+
+---
+
+## Mission 3（TD/Q-learning）
+### 目的
+- `q_learning` で学習し、greedy policy を導出し、deterministic GridWorld上で成功率（success_rate）を評価できるようにする。
+
+### 合格基準（ゲート）
+- `td_eval`（学習→評価）が複数seedで `success_rate` と `avg_return` を返す。
+- pytestで `success_rate >= 0.8` を**非flaky**にゲートする（環境は決定論・seed固定）。
+
+### テスト安定化の推奨設定
+- 環境は deterministic GridWorld（小さく簡単な構成）
+- ハイパーパラメータ（alpha/gamma/epsilon, episodes/max_steps）を固定
+- seeds例: `[0,1,2,3,4]` のように固定し平均
+
+---
+
+## PRに必ず書くこと（再現性）
+- Seed / Algorithm / Steps
+- Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes
+- A_j（影響obligation）: 変更が効くIDを列挙（1行1ID）


### PR DESCRIPTION
### Motivation
- Align repository documentation and Codex prompt templates with the provided SIRIUS assets so contributor guidance is consistent. 
- Make CI guidance explicit to prioritize non-flaky practices (seed-fixed RNG, deterministic env, minimal diffs) in the docs. 
- Surface obligations/pass-criteria in repository templates so authors reference the correct A_j IDs when opening issues or PRs. 

### Description
- Updated `AGENTS.md` to the canonical SIRIUS guidance (minimal diff, seed-fixed RNG, non-flaky tests) and wording consistency. 
- Rewrote `docs/rl/obligations.md` and `docs/rl/pass_criteria.md` to publish the standardized A_j list and pass criteria for missions M1/M2/M3. 
- Converted `codex_prompts/sirius_task.md` and `codex_prompts/sirius_eval_gate.md` into structured prompt templates (frontmatter + argument hints + verification guidance). 
- Added a `contact_links` entry to `.github/ISSUE_TEMPLATE/config.yml` to point Issue creators to obligations/pass-criteria; affected obligations include `biz.common.pass_criteria.definition`, `gp.common.issue_form.fields`, `gp.common.pr_template.aj_required`, and `gp.common.pr_template.reproducibility`. 

### Testing
- No automated tests were run because the changes are documentation and template-only. 
- `pytest -q` was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d721c46308333aa864b9c9523e552)