### PR TITLE
Add root README with course directory overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# PT Spec
+
+Pythonトレーニング用の静的サイトとコース仕様（HTML / Python実装）をまとめたリポジトリです。ルートの`index.html`から各コース（VEGA / ALTAIR / DENEB / SPICA / RIGEL / SIRIUS）や関連ドキュメントへ遷移できます。
+
+## ディレクトリ構成（主要部分）
+
+```text
+pt-spec/
+├── index.html               # メインのランディングページ（コース一覧）
+├── index2.html              # トップページの別案
+├── docs/                    # リポジトリ説明やRL関連ドキュメント
+├── backlog/                 # Web/Electron向けBacklog（Issue下書き）
+├── desktop/                 # デスクトップ版向け資材
+├── scripts/                 # ルート共通スクリプト
+├── tests/                   # テストコード
+├── sirius_rl/               # SIRIUS RLコースのPython実装（agents/env/eval等）
+├── bt7/                     # VEGA: 1週間でBEAT楽器を作るコース（scope/index/overview/spec）
+├── bt30/                    # ALTAIR: 3ヶ月のBEAT楽器MVP Issue Pack（scope/index/overview/spec）
+├── qr/                      # DENEB: QR→CSVパイプライン仕様とサンプルQR
+├── btd/                     # SPICA: Beat Diffusion（条件付き生成）の設計/実装ガイド
+├── ec/                      # RIGEL: Eカード題材の観点束・obligationテスト設計
+├── rl/                      # SIRIUS RL: Bandit→GridWorld→Q-learningのページ一式
+├── tu/                      # SIRIUS(タロット)フルスタック: 占いアプリの仕様/Issue/デモ
+├── hp/                      # 宇宙テーマの別ホームページセット
+└── course_dark.css, requirements.txt ほか共有リソース
+```


### PR DESCRIPTION
### Motivation
- Provide a clear root-level entry that explains the repository purpose and how to navigate from the landing `index.html` to each course and supporting material.
- Surface the important course subdirectories (VEGA / ALTAIR / DENEB / SPICA / RIGEL / SIRIUS) so reviewers and contributors can find course content quickly.
- Improve discoverability of RL-related docs and implementation (`sirius_rl/`) that are important for the SIRIUS mission set and CI/seed conventions.

### Description
- Add `README.md` at repository root containing a short project summary and a textual directory tree with per-course one-line descriptions.
- Document shared assets and common support folders such as `docs/`, `backlog/`, `scripts/`, `tests/`, and `requirements.txt` for easier navigation.
- Keep the change documentation-only and minimal to avoid touching existing HTML/CSS or implementation files.
- Declare the applicable obligation identifier as `A_j: gp.01` in accordance with the repo's PR/obligation policy.

### Testing
- This is a documentation-only change and no automated tests were run against code (no `pytest` executed).
- Meta: `Seed: N/A`, `Algorithm: N/A`, `Steps: Added root README with directory overview`, `Time Spent(min): 25`, `Trials: 0`, `Outcome: Pass (doc-only)`, `Notes: Tests not run (docs only)`, `A_j: gp.01`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6ffb62308333baf2f853385c31b0)