### PR TITLE
Fix ruff invocation in CI workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
       - name: Lint
-        run: ruff .
+        run: ruff check .
 
       - name: Test
         run: pytest


### PR DESCRIPTION
### Motivation
- CI lint step failed with `error: unrecognized subcommand '.'` because the Ruff CLI expects the `check` subcommand.
- This change is a minimal, scoped fix to restore the lint step without modifying code or linters.

### Description
- Update `.github/workflows/python-ci.yml` to run `ruff check .` instead of `ruff .` in the Lint step. 
- No other files or runtime behavior were modified.

### Testing
- No automated tests were run because this is a workflow-only change. 
- Seed / Algorithm / Steps: N/A (workflow change only).
- Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes: 5 / 0 / N/A / CLI invocation fix.
- A_j: A_001

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d945d531c83339d3c3d2443945a79)