### PR TITLE
Add `sync:web` script to sync web assets into desktop/app

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -18,6 +18,16 @@ npm run start
 - 1200x820 のウィンドウが開き、`desktop/app/index.html` が表示されます。
 - セキュリティ設定は `nodeIntegration: false` / `contextIsolation: true` / `sandbox: true` で有効化しています。
 
+## Web 資産の同期
+
+ルートディレクトリで Web を更新したら、以下の順で同期・起動してください。
+
+```bash
+cd desktop
+npm run sync:web
+npm run start
+```
+
 ## Windows 向けビルド
 
 ```bash
@@ -25,4 +35,4 @@ cd desktop
 npm run dist:win
 ```
 
-`dist/` に NSIS インストーラが生成されます。Web 資産の同期は別 Issue で対応予定です。
+`dist/` に NSIS インストーラが生成されます。

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "start": "electron .",
+    "sync:web": "node ./scripts/sync-web-assets.mjs",
     "dist:win": "electron-builder -w"
   },
   "build": {

--- a/desktop/scripts/sync-web-assets.mjs
+++ b/desktop/scripts/sync-web-assets.mjs
@@ -20,12 +20,12 @@ async function copyAsset(assetPath) {
     return;
   }
 
-  await fsExtra.copy(source, destination, { dereference: true });
+  await fsExtra.copy(source, destination, { dereference: true, overwrite: true });
   console.log(`[sync-web] Copied: ${assetPath}`);
 }
 
 async function main() {
-  await fsExtra.emptyDir(destinationRoot);
+  await fsExtra.ensureDir(destinationRoot);
 
   for (const asset of assets) {
     // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
### Motivation
- Automate copying of root web assets into `desktop/app` so homepage updates are reflected in the desktop wrapper without manual file copying.
- Preserve relative links and directory structure so `desktop/app/index.html` continues to work after syncing.

### Description
- Add `sync:web` npm script in `desktop/package.json` that runs `node ./scripts/sync-web-assets.mjs`.
- Update `desktop/scripts/sync-web-assets.mjs` to ensure the destination exists and copy `index.html`, `index2.html`, `bt7/`, `bt30/`, and `qr/` with `overwrite: true` while skipping missing assets.
- Change the script to use `fsExtra.ensureDir` instead of emptying the directory so non-target files are not removed.
- Update `desktop/README.md` with the Web update → sync → start flow and example commands (`npm run sync:web`).

### Testing
- No automated tests were run for this change (`npm run sync:web` was not executed in CI for this PR). 
- Seed / Algorithm / Steps: N/A (deterministic file copy without randomness).
- Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes: 20 / 0 / N/A / Manual verification through code inspection.
- A_j:
  - A_1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d95c7fae08333846d3b92698dd6c6)