### PR TITLE
Fix ruff lint issues in dp, runner, and reproducibility test

### DIFF
--- a/sirius_rl/algorithms/dp.py
+++ b/sirius_rl/algorithms/dp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 from sirius_rl.env.gridworld import GridWorldEnv, Transition
 

--- a/sirius_rl/eval/runner.py
+++ b/sirius_rl/eval/runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List, Optional
 
 from sirius_rl.env.base import Environment, StepResult
 from sirius_rl.utils.logging import JsonlLogger

--- a/tests/test_seed_repro.py
+++ b/tests/test_seed_repro.py
@@ -10,7 +10,9 @@ def test_runner_reproducible():
     probs = [0.2, 0.8]
     env1 = BernoulliBanditEnv(probs)
     env2 = BernoulliBanditEnv(probs)
-    policy = lambda obs: 1  # always pick the best arm
+
+    def policy(_: object) -> int:
+        return 1
 
     res1 = evaluate_policy(env1, policy, steps=10, episodes=3, seed=42)
     res2 = evaluate_policy(env2, policy, steps=10, episodes=3, seed=42)


### PR DESCRIPTION
### Motivation
- `ruff` reported unused `Dict` imports and a lambda assignment error that caused CI to fail. 
- Keep changes minimal and non-invasive to preserve existing behavior and reproducibility. 

### Description
- Removed unused `Dict` import from `sirius_rl/algorithms/dp.py`. 
- Removed unused `Dict` import from `sirius_rl/eval/runner.py`. 
- Replaced the inline lambda in `tests/test_seed_repro.py` with a typed function `policy` to satisfy E731 while preserving test semantics. 

### Testing
- Ran `ruff check .` which completed with no errors (All checks passed!). 
- Seed / Algorithm / Steps: N/A (lint-only change); Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes: 10 / 1 / Pass / `ruff check .`. 
- A_j: A_1: Lint-only change; no runtime impact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9732ea508333ab284d47e54390da)