### PR TITLE
Add pywinauto+pytest E2E link navigation test and requirements

### DIFF
--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pywinauto
+pywin32
+pillow

--- a/automation/tests/test_links.py
+++ b/automation/tests/test_links.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+
+import pytest
+from pywinauto.application import Application
+from pywinauto.base_wrapper import BaseWrapper
+
+ARTIFACTS_DIR = Path(__file__).resolve().parent / "artifacts"
+
+
+@pytest.fixture(scope="session")
+def app_exe_path() -> Path:
+    """Return the configured Electron executable path."""
+    value = os.environ.get("APP_EXE")
+    if not value:
+        pytest.fail("APP_EXE environment variable is required.")
+    path = Path(value)
+    if not path.exists():
+        pytest.fail(f"APP_EXE does not exist: {path}")
+    return path
+
+
+def launch_app(app_exe: Path) -> Application:
+    """Launch the Electron app in E2E mode via pywinauto."""
+    cmdline = f'"{app_exe}" --e2e'
+    return Application(backend="uia").start(cmdline, timeout=10)
+
+
+def get_main_window(app: Application) -> BaseWrapper:
+    """Wait for the main window to become visible."""
+    window = app.window(title_re=r".*PT Spec Desktop.*")
+    window.wait("visible", timeout=10)
+    return window
+
+
+def retry_until(predicate: Callable[[], Optional[str]], timeout: float) -> Optional[str]:
+    """Retry a predicate until it returns a truthy string or times out."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = predicate()
+        if result:
+            return result
+        time.sleep(0.2)
+    return None
+
+
+def click_link(window: BaseWrapper, label: str) -> None:
+    """Click a labeled link within the main window."""
+    window.set_focus()
+    link = window.child_window(title=label, control_type="Hyperlink")
+    if not link.exists():
+        link = window.child_window(title=label)
+    link.wait("enabled", timeout=10)
+    link.click_input()
+
+
+def wait_for_path_suffix(window: BaseWrapper, expected_suffix: str) -> None:
+    """Wait for the PATH overlay to show the expected suffix."""
+    def predicate() -> Optional[str]:
+        overlay = window.child_window(title_re=r"^PATH: .*")
+        if not overlay.exists():
+            return None
+        text = overlay.window_text()
+        if text.endswith(expected_suffix):
+            return text
+        return None
+
+    result = retry_until(predicate, timeout=10)
+    assert result is not None, (
+        "PATH overlay did not update to expected suffix: "
+        f"{expected_suffix}"
+    )
+
+
+def save_screenshot(window: BaseWrapper, name: str) -> None:
+    """Save a screenshot for debugging if possible."""
+    try:
+        ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        path = ARTIFACTS_DIR / f"{name}_{timestamp}.png"
+        image = window.capture_as_image()
+        image.save(path)
+    except Exception:
+        return None
+
+
+def close_app(app: Application) -> None:
+    """Terminate the Electron application process."""
+    try:
+        app.kill()
+    except Exception:
+        return None
+
+
+def test_links_update_path(app_exe_path: Path) -> None:
+    """Click key links and verify the E2E PATH overlay updates."""
+    app = launch_app(app_exe_path)
+    window = get_main_window(app)
+
+    try:
+        scenarios = [
+            ("VEGAを開始", "bt7/index.html"),
+            ("ALTAIRを開始", "bt30/index.html"),
+            ("DENEBを開始", "qr/index.html"),
+        ]
+        for label, expected_suffix in scenarios:
+            click_link(window, label)
+            wait_for_path_suffix(window, expected_suffix)
+    except Exception:
+        save_screenshot(window, "test_links_update_path")
+        raise
+    finally:
+        close_app(app)


### PR DESCRIPTION
### Motivation
- Provide a minimal pywinauto+pytest E2E test harness to verify Electron app link navigation by observing the `PATH:` overlay in E2E mode.
- Make failures diagnosable by saving screenshots to an artifacts folder so UI issues can be investigated.

### Description
- Add `automation/requirements.txt` with `pytest`, `pywinauto`, `pywin32`, and `pillow` to declare test dependencies.
- Add `automation/tests/test_links.py` which requires `APP_EXE`, launches `APP_EXE --e2e` with `backend="uia"`, finds the main window, clicks the links "VEGAを開始", "ALTAIRを開始", and "DENEBを開始", and retries until the `PATH:` overlay updates to the expected suffix.
- Implement retry logic with a 10-second timeout, save a screenshot to `automation/tests/artifacts/` on failure, and ensure the app is terminated in a finally block; update overlay selector to `title_re=r"^PATH: .*"`.

### Testing
- No automated tests were executed in this environment because the test requires a Windows GUI app and `APP_EXE` to be set for a real Electron build.
- Seed: N/A; Algorithm: N/A; Steps: launch `APP_EXE --e2e`, click links, verify `PATH:` overlay suffixes via retry.
- Time Spent(min): 25; Trials: 0; Outcome: Not run (requires Windows GUI); Notes: run on a Windows self-hosted runner with an active desktop session and `APP_EXE` pointing to the built Electron executable.
- A_j (impact obligation): A_1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da481593483339fe61b24f1b57708)