### PR TITLE
Update E2E artifacts location for pywinauto tests

### DIFF
--- a/automation/tests/test_links.py
+++ b/automation/tests/test_links.py
@@ -10,7 +10,7 @@ import pytest
 from pywinauto.application import Application
 from pywinauto.base_wrapper import BaseWrapper
 
-ARTIFACTS_DIR = Path(__file__).resolve().parent / "artifacts"
+ARTIFACTS_DIR = Path(__file__).resolve().parents[1] / "artifacts"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### Motivation
- Ensure E2E failure screenshots are stored in a consistent top-level location under `automation/artifacts` for easier collection.
- Make artifacts accessible from CI/workspace without scattering per-test directories.
- Keep the change minimal and focused only on artifact path configuration.

### Description
- Update `ARTIFACTS_DIR` in `automation/tests/test_links.py` to `Path(__file__).resolve().parents[1] / "artifacts"` so screenshots are saved to `automation/artifacts`.
- No other test logic or requirements were modified.

### Testing
- No automated UI tests were executed: `pytest` was not run because Windows UI automation is not available in the CI environment.
- Seed / Algorithm / Steps: `N/A` / `N/A` / `N/A`.
- Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes: `5` / `0` / `Not run` / `UI automation not available`.
- A_j (影響obligation): `A_j: None`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db04daea08333b103a59f310e7142)