### PR TITLE
Add Windows desktop build workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,55 @@
+name: Desktop Build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        working-directory: desktop
+        run: npm ci
+
+      - name: Sync web
+        working-directory: desktop
+        run: npm run sync:web
+
+      - name: Build NSIS installer
+        working-directory: desktop
+        run: npm run dist:win
+
+      - name: Build unpacked directory
+        working-directory: desktop
+        run: npx electron-builder -w --dir
+
+      - name: Zip unpacked build
+        working-directory: desktop
+        run: |
+          Compress-Archive -Path dist/win-unpacked/* -DestinationPath dist/desktop-win-unpacked.zip
+
+      - name: Upload win-unpacked artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-win-unpacked
+          path: desktop/dist/desktop-win-unpacked.zip
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-win-installer
+          path: desktop/dist/*.exe
+          retention-days: 7
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Provide a CI workflow to build the Windows Electron NSIS installer and unpacked artifacts for distribution and testing.
- Allow manual runs via `workflow_dispatch` and automatic runs on `push` to `main`.
- Produce both NSIS installer and a `win-unpacked` zip so installers and unpacked builds are available as artifacts.

### Description
- Add `.github/workflows/desktop-build.yml` which defines job `build-windows` running on `windows-latest` with steps for `actions/checkout`, `actions/setup-node`, `npm ci` (in `desktop`), `npm run sync:web`, `npm run dist:win`, and `npx electron-builder -w --dir`.
- Zip the `win-unpacked` output using `Compress-Archive` and upload artifacts using `actions/upload-artifact@v4` with names `desktop-win-unpacked` and `desktop-win-installer`.
- Artifacts are uploaded with `retention-days: 7` and the workflow triggers on `push` to `main` and `workflow_dispatch` for manual runs.

### Testing
- No automated tests were run in the repository for this change because it only adds a CI workflow and will be executed when the workflow is triggered in GitHub Actions.
- Seed / Algorithm / Steps: N/A (workflow change).
- Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes: 10 / 0 / Not run / Workflow file added and validated locally.
- A_j (impact obligation): A_1.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db0e98b148333915d7cacbe0093b9)