### PR TITLE
Add Windows UI test job for desktop build workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Zip unpacked build
         working-directory: desktop
         run: |
-          Compress-Archive -Path dist/win-unpacked/* -DestinationPath dist/desktop-win-unpacked.zip
+          Compress-Archive -Path dist/win-unpacked/* -DestinationPath dist/win-unpacked.zip
 
       - name: Upload win-unpacked artifact
         uses: actions/upload-artifact@v4
         with:
           name: desktop-win-unpacked
-          path: desktop/dist/desktop-win-unpacked.zip
+          path: desktop/dist/win-unpacked.zip
           retention-days: 7
           if-no-files-found: error
 
@@ -53,3 +53,56 @@ jobs:
           path: desktop/dist/*.exe
           retention-days: 7
           if-no-files-found: error
+
+  ui-tests-windows:
+    runs-on: [self-hosted, windows, win-uia]
+    needs: build-windows
+    concurrency:
+      group: desktop-ui-tests-windows
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download win-unpacked artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-win-unpacked
+
+      - name: Extract win-unpacked
+        run: |
+          Expand-Archive -Path win-unpacked.zip -DestinationPath win-unpacked
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UI test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r automation/requirements.txt
+
+      - name: Set APP_EXE
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Path win-unpacked -Filter *.exe -Recurse | Select-Object -First 1
+          if (-not $exe) { throw "APP_EXE not found in win-unpacked" }
+          "APP_EXE=$($exe.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Run UI tests
+        shell: pwsh
+        run: |
+          pytest -q 2>&1 | Tee-Object -FilePath automation/pytest.log
+
+      - name: Upload UI test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-ui-test-artifacts
+          path: |
+            automation/pytest.log
+            automation/screenshots
+            automation/test-results
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
### Motivation
- Add a Windows UI test job to run `pywinauto`-based tests on a self-hosted Windows runner with labels `[self-hosted, windows, win-uia]` to enable end-to-end desktop UI validation.
- Align the unpacked artifact name so the UI job can reliably download and extract the build (`desktop-win-unpacked` -> `win-unpacked.zip`).
- Prevent concurrent UI runs by adding a `concurrency` group so only one UI test job runs at a time.
- A_j: workflow-ci

### Description
- Renamed the zipped unpacked build to `win-unpacked.zip` and updated the upload path in `desktop-build.yml`.
- Added a `ui-tests-windows` job that `needs: build-windows`, runs on `runs-on: [self-hosted, windows, win-uia]`, and uses a concurrency group `desktop-ui-tests-windows`.
- The job downloads and extracts the `desktop-win-unpacked` artifact, sets up Python via `actions/setup-python`, installs UI deps with `pip install -r automation/requirements.txt`, discovers the app executable and exports `APP_EXE`, runs `pytest -q`, and uploads test artifacts (`automation/pytest.log`, `automation/screenshots`, `automation/test-results`).
- Artifact download uses `actions/download-artifact@v4` and uploads use `actions/upload-artifact@v4`, and PowerShell steps set `APP_EXE` into the environment for tests.

### Testing
- No automated tests were run as this change modifies CI workflow configuration only and workflows have not been executed in this PR.
- Verification steps expected when the workflow runs: the `ui-tests-windows` job should successfully download `desktop-win-unpacked`, extract it, locate an `.exe`, run `pytest -q`, and upload artifacts.
- Seed: N/A; Algorithm: N/A; Steps: N/A.
- Time Spent (min): 15; Trials: 0; Outcome: Not Run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db18e61288333b4e857bca5e6671a)