### PR TITLE
Skip pywinauto UI tests when dependency missing

### DIFF
--- a/automation/tests/test_links.py
+++ b/automation/tests/test_links.py
@@ -7,8 +7,12 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import pytest
-from pywinauto.application import Application
-from pywinauto.base_wrapper import BaseWrapper
+
+try:
+    from pywinauto.application import Application
+    from pywinauto.base_wrapper import BaseWrapper
+except ModuleNotFoundError:
+    pytest.skip("pywinauto is required for Windows UI automation tests.", allow_module_level=True)
 
 ARTIFACTS_DIR = Path(__file__).resolve().parents[1] / "artifacts"
 


### PR DESCRIPTION
### Motivation
- CI test collection failed due to a missing `pywinauto` import which caused an error during pytest collection.
- The failing tests are Windows UI automation and should be skipped in environments without the `pywinauto` dependency.
- Make a minimal change that prevents import-time failures without refactoring test logic.
- Preserve CI stability and non-flakiness by avoiding running platform-specific tests when prerequisites are absent.

### Description
- Wrap the `pywinauto` imports in a `try/except ModuleNotFoundError` and call `pytest.skip(..., allow_module_level=True)` to skip the module when unavailable.
- The change was made in `automation/tests/test_links.py` and does not modify test logic or fixtures.
- No behavioral change to the test functions; they will run normally when `pywinauto` is installed.

### Testing
- No full test suite was executed as this change is targeted at CI import behavior, and the skip avoids collection errors when `pywinauto` is missing.
- With `pywinauto` absent, `pytest` will now skip `automation/tests/test_links.py` during collection instead of failing on import.
- Time Spent: 10 min; Trials: 0; Outcome: Not run.
- A_j (impact obligation): A_j-1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db9f781048333965f762b08fcf465)