### PR TITLE
Normalize Windows installer to Setup.exe and align desktop docs/workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -29,6 +29,14 @@ jobs:
         working-directory: desktop
         run: npm run dist:win
 
+      - name: Normalize installer name
+        working-directory: desktop
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem -Path dist -Filter *.exe -File | Select-Object -First 1
+          if (-not $installer) { throw "Installer .exe not found in dist" }
+          Copy-Item -Path $installer.FullName -Destination (Join-Path $installer.DirectoryName "Setup.exe") -Force
+
       - name: Build unpacked directory
         working-directory: desktop
         run: npx electron-builder -w --dir
@@ -50,7 +58,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: desktop-win-installer
-          path: desktop/dist/*.exe
+          path: desktop/dist/Setup.exe
           retention-days: 7
           if-no-files-found: error
 

--- a/backlog/desktop-e2e/S-E2E-DESKTOP-01.md
+++ b/backlog/desktop-e2e/S-E2E-DESKTOP-01.md
@@ -17,7 +17,7 @@ EST_SIZE: M
 
 スコープ：
 - `desktop/` 配下に Electron 基本ファイル（`package.json`, `main.js`, `preload.js`, `README.md`, `app/` ダミー `index.html`）を追加。
-- `BrowserWindow(1200x820)` で `desktop/app/index.html` を `loadFile`。`ready-to-show` で表示開始。`window.open` は `shell.openExternal` に転送。
+- `BrowserWindow(1200x820)` で `app://bundle/index.html` を `loadURL`。`ready-to-show` で表示開始。`window.open` は `shell.openExternal` に転送。
 - `build.files` で `main.js`, `preload.js`, `app/**/*` を同梱し、`build.win.target: nsis` を設定。
 
 非スコープ：
@@ -26,7 +26,7 @@ EST_SIZE: M
 - CIビルド/テスト（Issue 5以降）
 
 受け入れ基準：
-- `cd desktop && npm install && npm run start` でWindowsにウィンドウが開き、`desktop/app/index.html` が表示される。
+- `cd desktop && npm install && npm run start` でWindowsにウィンドウが開き、`app://bundle/index.html` が表示される。
 - セキュリティ設定（`nodeIntegration:false`, `contextIsolation:true`, `sandbox:true`）が有効。
 
 ## H（How）/ Codex Prompt
@@ -38,12 +38,12 @@ EST_SIZE: M
   - build.files: main.js, preload.js, app/**/*
   - build.win.target: nsis
 - desktop/main.js:
-  - BrowserWindow(1200x820) で desktop/app/index.html を loadFile
+  - BrowserWindow(1200x820) で app://bundle/index.html を loadURL
   - nodeIntegration false, contextIsolation true, sandbox true, preload 有効
   - ready-to-showで表示（白フラッシュ防止）
   - window.openはshell.openExternalで外部ブラウザへ
 - desktop/preload.js: まずは空でOK
 - desktop/README.md: 開発起動とdist手順を記載
 
-既存Web資産は後続Issueで同期するので、現時点では desktop/app/index.html だけで動けばOK。
+既存Web資産は後続Issueで同期するので、現時点では app://bundle/index.html だけで動けばOK。
 ```

--- a/backlog/desktop-e2e/S-E2E-DESKTOP-02.md
+++ b/backlog/desktop-e2e/S-E2E-DESKTOP-02.md
@@ -13,7 +13,7 @@ EST_SIZE: M
 
 スコープ：
 - `npm run sync:web` のスクリプトを `desktop/package.json` に追加。
-- Node.jsスクリプト（例：`desktop/scripts/sync-web.js`）で以下をコピーする：
+- Node.jsスクリプト（`desktop/scripts/sync-web.js`）で以下をコピーする：
   - `index.html`, `index2.html`
   - `bt7/`, `bt30/`, `qr/` （存在するものだけ）
 - 既存ファイルは上書きでOK。相対リンクを壊さないようディレクトリ構造を維持。
@@ -32,12 +32,12 @@ desktop/ に Web資産同期機能を実装してください。
 
 要件:
 - desktop/package.json に "sync:web" スクリプトを追加
-- Node.js で動く同期スクリプトを desktop/scripts/sync-web.js などとして追加
+- Node.js で動く同期スクリプトを desktop/scripts/sync-web.js として追加
 - コピー元: リポジトリルート
 - コピー先: desktop/app
 - 対象: index.html, index2.html, bt7/, bt30/, qr/ （存在するものだけコピー）
 - 既存ファイルは上書き。不要ファイルは消しても良いが、まずは上書きでOK
-- これにより `desktop/app/index.html` からの相対リンクが壊れない状態を保証する
+- これにより `app://bundle/index.html` からの相対リンクが壊れない状態を保証する
 
 合わせて README に「Web更新→sync→start」の流れを追記してください。
 ```

--- a/backlog/desktop-e2e/S-E2E-DESKTOP-05.md
+++ b/backlog/desktop-e2e/S-E2E-DESKTOP-05.md
@@ -9,7 +9,7 @@ EST_SIZE: L
 
 ## S（Spec）/ 仕様
 目的：
-- `push main` および `workflow_dispatch` でGitHub ActionsがElectronのWindows成果物を生成し、`win-unpacked.zip`（テスト用）と `Setup.exe`（配布用）をartifactとして残す。
+- `push main` および `workflow_dispatch` でGitHub ActionsがElectronのWindows成果物を生成し、`win-unpacked.zip`（テスト用）と `Setup.exe`（配布用、dist/*.exe を正規化）をartifactとして残す。
 
 スコープ：
 - `.github/workflows/desktop-build.yml` を追加（または既存ワークフローにジョブ追加）。
@@ -18,6 +18,7 @@ EST_SIZE: L
   - `cd desktop && npm ci`。
   - `npm run sync:web` でWeb資産同期。
   - `npm run dist:win` でNSISインストーラ生成。
+  - `dist/` 内のインストーラ `.exe` を `Setup.exe` に正規化。
   - `electron-builder -w --dir` で `win-unpacked` を生成しzip化。
   - `actions/upload-artifact` で `desktop-win-unpacked` と `desktop-win-installer` をアップロード（保持日数は短めで可）。
 
@@ -26,7 +27,7 @@ EST_SIZE: L
 - pywinauto実装（Issue 4）
 
 受け入れ基準：
-- `main` へのpushまたは手動実行でworkflowが成功し、Actions artifactに `win-unpacked.zip` と `Setup.exe` が保存される。
+- `main` へのpushまたは手動実行でworkflowが成功し、Actions artifactに `win-unpacked.zip` と `Setup.exe`（正規化済み）が保存される。
 
 ## H（How）/ Codex Prompt
 GitHub ActionsでElectronのWindows成果物を作るworkflowを追加してください。
@@ -40,6 +41,7 @@ GitHub ActionsでElectronのWindows成果物を作るworkflowを追加してく�
   - `cd desktop && npm ci`
   - `npm run sync:web`
   - `npm run dist:win`（NSIS installer）
+  - dist/*.exe を Setup.exe に正規化
   - 追加で `electron-builder -w --dir` も実行して win-unpacked を作りzip化（テスト用）
   - actions/upload-artifact で
     - artifact name: desktop-win-unpacked

--- a/backlog/desktop-e2e/S-E2E-DESKTOP-ALL.md
+++ b/backlog/desktop-e2e/S-E2E-DESKTOP-ALL.md
@@ -31,12 +31,12 @@ EST_SIZE: XL
 
 ### タスクA（Issue 1相当）：Electron最小ラッパー追加
 - `desktop/` に Electron 基本ファイル（package.json, main.js, preload.js, README.md, app/index.htmlダミー）を追加。
-- BrowserWindow(1200x820) で `desktop/app/index.html` を `loadFile`。`ready-to-show` で表示。`window.open` を `shell.openExternal` に転送。
+- BrowserWindow(1200x820) で `app://bundle/index.html` を `loadURL`。`ready-to-show` で表示。`window.open` を `shell.openExternal` に転送。
 - セキュリティ：`nodeIntegration:false`、`contextIsolation:true`、`sandbox:true`。`build.win.target: nsis`、`build.files` に main.js/preload.js/app/*** を含める。
 - 受入れ：`cd desktop && npm install && npm run start` でWindows起動し、app/index.html表示。
 
 ### タスクB（Issue 2相当）：Web資産同期スクリプト
-- `npm run sync:web` を `desktop/package.json` に追加。Nodeスクリプトを `desktop/scripts/sync-web.js` 等で実装。
+- `npm run sync:web` を `desktop/package.json` に追加。Nodeスクリプトは `desktop/scripts/sync-web.js` を使用。
 - ルートから `index.html`, `index2.html`, `bt7/`, `bt30/`, `qr/`（存在分のみ）を `desktop/app/` にコピー。上書きでOK。
 - READMEに「Web更新→sync→start」手順を追記。
 - 受入れ：`npm run sync:web` 後に相対リンクが壊れず `npm run start` で閲覧できる。
@@ -56,7 +56,7 @@ EST_SIZE: XL
 ### タスクE（Issue 5相当）：ActionsでWindows成果物ビルド
 - `.github/workflows/desktop-build.yml` を追加。trigger: `push`(main) + `workflow_dispatch`。
 - ジョブ build-windows（runs-on: windows-latest）：checkout→Node LTS→`cd desktop && npm ci`→`npm run sync:web`→`npm run dist:win`（NSIS installer）→`electron-builder -w --dir` で `win-unpacked` 生成→zip化。
-- `actions/upload-artifact` で `desktop-win-unpacked`（win-unpacked.zip）と `desktop-win-installer`（Setup.exe）をアップロード（保存日数短め可）。
+- `actions/upload-artifact` で `desktop-win-unpacked`（win-unpacked.zip）と `desktop-win-installer`（Setup.exe, dist/*.exe から正規化）をアップロード（保存日数短め可）。
 - 受入れ：workflow成功しartifact2種が取得できる。
 
 ### タスクF（Issue 6相当）：self-hosted runnerでUIテスト

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,6 +1,6 @@
 # デスクトップラッパー最小構成
 
-Electron で `desktop/app/index.html` を表示する最小セットです。既存の静的 HTML は後続の Issue で同期予定のため、現在はダミーの `index.html` を読み込ませています。
+Electron で `app://bundle/index.html` を表示する最小セットです（`desktop/app/` を配信）。既存の静的 HTML は後続の Issue で同期予定のため、現在はダミーの `index.html` を読み込ませています。
 
 ## 前提
 
@@ -15,7 +15,7 @@ npm install
 npm run start
 ```
 
-- 1200x820 のウィンドウが開き、`desktop/app/index.html` が表示されます。
+- 1200x820 のウィンドウが開き、`app://bundle/index.html` が表示されます。
 - セキュリティ設定は `nodeIntegration: false` / `contextIsolation: true` / `sandbox: true` で有効化しています。
 
 ## Web 資産の同期
@@ -35,7 +35,11 @@ cd desktop
 npm run dist:win
 ```
 
-`dist/` に NSIS インストーラが生成されます。
+`dist/` に `PT Spec Setup <version>.exe` 形式の NSIS インストーラが生成されます。GitHub Actions では `Setup.exe` に正規化して artifact に保存します。
+
+## CI（Windows self-hosted runner）
+
+UIテストは `runs-on: [self-hosted, windows, win-uia]` を要求します。セットアップ手順は `docs/windows-runner-setup.md` を参照してください。
 
 ## E2Eモード（PATHオーバーレイ）
 

--- a/docs/desktop_e2e_manual.md
+++ b/docs/desktop_e2e_manual.md
@@ -246,11 +246,11 @@ pywinautoのリモート実行ガイドでも、RDP最小化/切断でアクテ�
 ## Issue 1: `desktop/` にElectronラッパーの最小構成を追加する
 
 **目的**
-静的サイトを `file://` で読み込むElectronアプリを起動できるようにする。
+静的サイトを `app://bundle/index.html` で読み込むElectronアプリを起動できるようにする。
 
 **受け入れ条件**
 
-* `npm install` → `npm run start` でWindows上にウィンドウが開き、`desktop/app/index.html` が表示される
+* `npm install` → `npm run start` でWindows上にウィンドウが開き、`app://bundle/index.html` が表示される
 * セキュリティ推奨（`nodeIntegration: false`, `contextIsolation: true`, `sandbox: true`）を維持
 
 **Codex用プロンプト**
@@ -265,14 +265,14 @@ pywinautoのリモート実行ガイドでも、RDP最小化/切断でアクテ�
   - build.files: main.js, preload.js, app/**/*
   - build.win.target: nsis
 - desktop/main.js:
-  - BrowserWindow(1200x820) で desktop/app/index.html を loadFile
+  - BrowserWindow(1200x820) で app://bundle/index.html を loadURL
   - nodeIntegration false, contextIsolation true, sandbox true, preload 有効
   - ready-to-showで表示（白フラッシュ防止）
   - window.openはshell.openExternalで外部ブラウザへ
 - desktop/preload.js: まずは空でOK
 - desktop/README.md: 開発起動とdist手順を記載
 
-既存Web資産は後続Issueで同期するので、現時点では desktop/app/index.html だけで動けばOK。
+既存Web資産は後続Issueで同期するので、現時点では app://bundle/index.html だけで動けばOK。
 ```
 
 ---
@@ -295,12 +295,12 @@ desktop/ に Web資産同期機能を実装してください。
 
 要件:
 - desktop/package.json に "sync:web" スクリプトを追加
-- Node.js で動く同期スクリプトを desktop/scripts/sync-web.js などとして追加
+- Node.js で動く同期スクリプトを desktop/scripts/sync-web.js として追加
 - コピー元: リポジトリルート
 - コピー先: desktop/app
 - 対象: index.html, index2.html, bt7/, bt30/, qr/ （存在するものだけコピー）
 - 既存ファイルは上書き。不要ファイルは消しても良いが、まずは上書きでOK
-- これにより `desktop/app/index.html` からの相対リンクが壊れない状態を保証する
+- これにより `app://bundle/index.html` からの相対リンクが壊れない状態を保証する
 
 合わせて README に「Web更新→sync→start」の流れを追記してください。
 ```

--- a/docs/desktop_pipeline_report.md
+++ b/docs/desktop_pipeline_report.md
@@ -17,8 +17,9 @@ Webアプリ更新後に「Windows向けビルド → 配布 → デプロイ �
   |   ├─ npm ci
   |   ├─ npm run sync:web
   |   ├─ npm run dist:win (NSIS installer)
+  |   ├─ dist/*.exe を Setup.exe に正規化
   |   ├─ electron-builder -w --dir (unpacked)
-  |   └─ artifacts: win-unpacked.zip / Setup.exe
+  |   └─ artifacts: win-unpacked.zip / Setup.exe（正規化済み）
   |
   └─ job: ui-tests-windows (self-hosted, windows, win-uia)
       ├─ artifacts download
@@ -38,8 +39,8 @@ Webアプリ更新後に「Windows向けビルド → 配布 → デプロイ �
 | 1. Web更新 | 開発端末 or GitHub | HTMLや静的ファイルを更新しコミット | - | Git履歴（コミット） |
 | 2. ビルド準備 | GitHub Actions (windows-latest) | Node.jsセットアップ & 依存インストール | - | Actionsログ |
 | 3. Web同期 | GitHub Actions (windows-latest) | `npm run sync:web` で `desktop/app/` に同期 | - | Actionsログ |
-| 4. Windowsビルド | GitHub Actions (windows-latest) | NSIS/Unpackedビルド | - | `desktop-win-unpacked` / `desktop-win-installer` artifacts |
-| 5. 配布 | GitHub Actions | artifacts を保存 | - | artifacts（zip/exe） |
+| 4. Windowsビルド | GitHub Actions (windows-latest) | NSIS/Unpackedビルド + installer名を `Setup.exe` に正規化 | - | `desktop-win-unpacked` / `desktop-win-installer` artifacts |
+| 5. 配布 | GitHub Actions | artifacts を保存 | - | artifacts（zip/Setup.exe） |
 | 6. デプロイ | self-hosted runner | win-unpacked 展開 & EXE準備 | - | Actionsログ |
 | 7. UIテスト | self-hosted runner | `pytest -q` (pywinauto) | **UIテスト結果** | `desktop-ui-test-artifacts` (pytest.log / screenshots / test-results) |
 

--- a/docs/windows-runner-setup.md
+++ b/docs/windows-runner-setup.md
@@ -7,8 +7,14 @@
 ## self-hosted runner の追加手順
 1) GitHub の **Settings → Actions → Runners → New self-hosted runner** を開く。
 2) **Windows / x64** を選択し、表示される手順に従って runner をダウンロード・展開する（例: `C:\actions-runner`）。
-3) 管理者 PowerShell で表示された `config.cmd` を実行して登録する。
+3) 管理者 PowerShell で表示された `config.cmd --labels win-uia` を実行して登録する。
 4) **Windowsサービスとして登録しない**。GUIテストでは対話的なデスクトップが必要なため、ログインしたユーザーのセッションで `run.cmd` を起動し、そのまま開いておく。
+
+## win-uia ラベルの付与/確認
+- `ui-tests-windows` ジョブは `runs-on: [self-hosted, windows, win-uia]` を要求するため、**win-uia ラベルが必須**。
+- 既存 runner に後付けする場合は、`run.cmd` を停止したうえで `config.cmd --labels win-uia` を再実行する。
+  - ラベルが更新されない場合は `config.cmd remove` → `config.cmd --labels win-uia` で再登録する。
+- GitHub の **Settings → Actions → Runners** で該当 runner に `win-uia` が付いていることを確認する。
 
 ## 常時ログイン・ロック/スリープ無効化の指針
 - runner 用アカウントで常時ログインしたままにする。


### PR DESCRIPTION
### Motivation
- Fix mismatches between docs, issue specs, and CI about the Windows installer filename (local `PT Spec Setup <version>.exe` vs docs expecting `Setup.exe`).
- Ensure the UI test job requirements (`win-uia` runner label) are documented and reproducible for self-hosted runners.
- Bring issue specs and manuals in line with the current Electron behavior (`app://bundle/index.html`) and `desktop/scripts/sync-web.js` usage.
- Make minimal changes that preserve the current implementation while preventing operator confusion in CI and runbooks.

### Description
- Normalize installer artifact in the build workflow by copying the produced `dist/*.exe` to `desktop/dist/Setup.exe` and upload that from `.github/workflows/desktop-build.yml` via `actions/upload-artifact`.
- Clarified local vs CI installer naming and `app://bundle` launch behavior in `desktop/README.md` and documented that CI normalizes to `Setup.exe`.
- Added `win-uia` labeling instructions and verification guidance to `docs/windows-runner-setup.md` (use `config.cmd --labels win-uia`) so the `runs-on: [self-hosted, windows, win-uia]` job requirement is actionable.
- Updated pipeline report, e2e manual, and backlog issue specs to reference `app://bundle/index.html`, use `desktop/scripts/sync-web.js`, and note the installer-name normalization; files changed include `.github/workflows/desktop-build.yml`, `desktop/README.md`, `docs/desktop_pipeline_report.md`, `docs/windows-runner-setup.md`, `docs/desktop_e2e_manual.md`, and `backlog/desktop-e2e/S-E2E-DESKTOP-01.md`, `S-E2E-DESKTOP-02.md`, `S-E2E-DESKTOP-05.md`, `S-E2E-DESKTOP-ALL.md`.

### Testing
- No automated tests were run as part of this change because the edits are documentation and workflow adjustments only.
- The repository changes were lint/checked via repository search tools to ensure references were updated and the commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc004e5748333a6193cab5e2c2af6)