### PR TITLE
Add pywinauto environment verification steps

### DIFF
--- a/docs/windows-runner-setup.md
+++ b/docs/windows-runner-setup.md
@@ -21,6 +21,51 @@
 - スリープ、画面オフ、ロックを無効化する（テスト実行時間を通じて画面が操作可能であることが必須）。
 - リモート接続を使う場合も、コンソールセッションが維持される方式で接続し、セッション切断やロックを避ける。
 
+## pywinauto 仮想環境の動作確認（依存ライブラリの確認）
+> 目的: pywinauto と周辺ライブラリ（pylon、pywin32、comtypes）がインポートできるかを **対話セッション上** で確認する。
+
+### 1) 仮想環境を有効化
+例: pywinauto の仮想環境が `C:\path\to\venv` にある場合
+
+```powershell
+cd C:\path\to\venv
+.\Scripts\Activate.ps1
+```
+
+### 2) バージョン確認（インストール済みの確認）
+```powershell
+python -m pip show pywinauto pypylon pywin32 comtypes
+```
+
+### 3) インポートのスモークテスト
+```powershell
+python - <<'PY'
+import pywinauto
+import pypylon
+import win32api
+import comtypes
+print("pywinauto", pywinauto.__version__)
+print("pypylon", pypylon.__version__)
+print("pywin32", win32api.__file__)
+print("comtypes", comtypes.__version__)
+PY
+```
+
+### 4) UI 制御の最小確認（電卓を開けるか）
+> ※ GUI セッション上で実行すること（ロック/切断状態では失敗しやすい）
+
+```powershell
+python - <<'PY'
+from pywinauto import Application
+
+app = Application(backend="uia").start("calc.exe")
+window = app.window(title_re=".*電卓.*|.*Calculator.*")
+window.wait("visible", timeout=10)
+app.kill()
+print("OK")
+PY
+```
+
 ## トラブル時の対処
 - **runner が落ちた**: `run.cmd` のコンソールが閉じていないか確認し、ログイン後に再度 `run.cmd` を起動する。
 - **画面ロックで失敗する**: ロック解除後に再実行し、電源/ロック設定を再確認する。


### PR DESCRIPTION
### Motivation
- Provide a minimal, reproducible smoke-test procedure to verify `pywinauto` and its dependencies on Windows self-hosted runners.
- Ensure operators can validate the virtual environment and basic UI control (opening Calculator) before running GUI E2E tests.
- Keep the change small and documentation-only to avoid impacting code or CI behavior.

### Description
- Added a new `pywinauto 仮想環境の動作確認` section to `docs/windows-runner-setup.md` with step-by-step checks. 
- The section includes commands to activate the virtualenv, run `python -m pip show` for `pywinauto pypylon pywin32 comtypes`, perform an import smoke test, and a simple `calc.exe` UI start/kill sample using `pywinauto`.
- No code, tests, or CI workflow files were modified; this is a documentation-only update.
- The instructions are intended for interactive GUI sessions and follow the repository guidance to keep checks simple and non-flaky.

### Testing
- Automated tests were not run because this is a documentation-only change. 
- Seed / Algorithm / Steps: N/A. 
- Time Spent(min) / Trials / Outcome(Pass/Fail) / Notes: 10 / 0 / Pass / doc update. 
- A_j（影響obligation）: docs-windows-runner-setup

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de86e094c8333bac9a4b6a432d5ca)