### PR TITLE
Verify Python SSL/ensurepip in Windows UI test workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -86,6 +86,14 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Verify Python SSL and pip
+        run: |
+          python - <<'PY'
+          import ssl
+          print(ssl.OPENSSL_VERSION)
+          PY
+          python -m ensurepip --upgrade
+
       - name: Install UI test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/windows-runner-setup.md
+++ b/docs/windows-runner-setup.md
@@ -70,6 +70,10 @@ PY
 - **runner が落ちた**: `run.cmd` のコンソールが閉じていないか確認し、ログイン後に再度 `run.cmd` を起動する。
 - **画面ロックで失敗する**: ロック解除後に再実行し、電源/ロック設定を再確認する。
 - **UIが掴めない/競合する**: 以前のテストで残ったアプリを終了してから runner を再起動する。
+- **`No module named pip` / `ssl module is not available` で `pip install` が失敗する**:
+  - 原因: `actions/setup-python` が参照する Python の SSL/ensurepip が欠けている（ツールキャッシュの破損など）。
+  - 対策: `C:\actions-runner\_work\_tool\Python\` を削除して再取得するか、公式インストーラで Python を再インストールする。
+  - 追加確認: `python -c "import ssl; print(ssl.OPENSSL_VERSION)"` が通ることを確認する。
 
 ## iPhone からの運用
 - GitHub のモバイル/ブラウザで **Actions → 対象ワークフロー → Run workflow** を実行できる。


### PR DESCRIPTION
### Motivation
- Windows UI test jobs were failing when `pip install` could not reach PyPI due to the Python `ssl` module or `pip` being unavailable, causing package installs (e.g. `pillow`) to error.
- The intent is to surface broken Python toolchains early in the workflow and provide clear remediation steps for self-hosted Windows runners.

### Description
- Add a `Verify Python SSL and pip` step to `.github/workflows/desktop-build.yml` which runs `python - <<'PY'\nimport ssl\nprint(ssl.OPENSSL_VERSION)\nPY` and `python -m ensurepip --upgrade` before installing UI test dependencies.
- Document the observed failure mode and remediation in `docs/windows-runner-setup.md`, advising to remove `C:\actions-runner\_work\_tool\Python\` for re-acquisition or to reinstall Python, and to verify `python -c "import ssl; print(ssl.OPENSSL_VERSION)"` succeeds.
- Changes are intentionally minimal and limited to a workflow guardrail and documentation updates.

### Testing
- No automated tests were executed as part of this change; the CI workflows were not run in this update.
- The files were committed and basic YAML/text inspection was performed, but full CI validation will occur when the workflow runs in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec1d8ae948333b9a4f7bd6d997dd5)