### PR TITLE
Fix Windows verify Python step in desktop build workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -88,10 +88,7 @@ jobs:
 
       - name: Verify Python SSL and pip
         run: |
-          python - <<'PY'
-          import ssl
-          print(ssl.OPENSSL_VERSION)
-          PY
+          python -c "import ssl; print(ssl.OPENSSL_VERSION)"
           python -m ensurepip --upgrade
 
       - name: Install UI test dependencies


### PR DESCRIPTION
### Motivation
- The Windows runner used PowerShell which made the Bash-style here-document (`python - <<'PY'`) fail to run as intended.
- The step needs to print the OpenSSL version from Python and then upgrade `ensurepip` reliably on Windows.

### Description
- Replaced the multi-line here-doc invocation `python - <<'PY' ... PY` with a PowerShell-friendly one-liner `python -c "import ssl; print(ssl.OPENSSL_VERSION)"`.
- Kept the following `python -m ensurepip --upgrade` invocation unchanged to ensure pip is available and up-to-date.
- The change was applied to `.github/workflows/desktop-build.yml` in the Windows UI test job (lines ~89-92).

### Testing
- No automated tests were run for this change because it only modifies a CI workflow file and does not affect runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef806658c8333b4e82b7aa8be6e68)