### PR TITLE
Fix PowerShell shell selection for self-hosted Windows UI tests

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -65,6 +65,9 @@ jobs:
   ui-tests-windows:
     runs-on: [self-hosted, windows, win-uia]
     needs: build-windows
+    defaults:
+      run:
+        shell: powershell
     concurrency:
       group: desktop-ui-tests-windows
       cancel-in-progress: false
@@ -97,14 +100,12 @@ jobs:
           python -m pip install -r automation/requirements.txt
 
       - name: Set APP_EXE
-        shell: pwsh
         run: |
           $exe = Get-ChildItem -Path win-unpacked -Filter *.exe -Recurse | Select-Object -First 1
           if (-not $exe) { throw "APP_EXE not found in win-unpacked" }
           "APP_EXE=$($exe.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Run UI tests
-        shell: pwsh
         run: |
           pytest -q 2>&1 | Tee-Object -FilePath automation/pytest.log
 


### PR DESCRIPTION
### Motivation
- The self-hosted Windows UI test job failed with `pwsh: command not found` when the runner did not provide `pwsh`.
- The job should run commands under Windows PowerShell to ensure `Get-ChildItem`, `Out-File`, and `Tee-Object` are available on self-hosted Windows runners.
- Keep changes minimal and confined to the workflow to avoid touching test code or behavior.
- A_j: `desktop-ui-tests-shell`.

### Description
- Add `defaults.run.shell: powershell` to the `ui-tests-windows` job in `.github/workflows/desktop-build.yml` so steps use Windows PowerShell by default.
- Remove explicit `shell: pwsh` from the `Set APP_EXE` and `Run UI tests` steps so they inherit the job default.
- No changes to the test commands or artifact upload logic, only the shell selection for the job.

### Testing
- This is a workflow-only change and no unit tests or `pytest` runs were executed as part of this change.
- The YAML was updated and committed, and the change is minimal to the workflow file; no CI run was invoked here.
- Manual inspection verifies that `Set APP_EXE` uses `Get-ChildItem` and environment export via `Out-File` under `powershell`.
- Outcome: workflow change only (no automated tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f07d7a5888333a9ce180875b61259)