### PR TITLE
Collect Windows diagnostics on UI test failure and upload artifacts

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -109,6 +109,12 @@ jobs:
         run: |
           pytest -q 2>&1 | Tee-Object -FilePath automation/pytest.log
 
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          if (-not $env:APP_EXE) { throw "APP_EXE is not set" }
+          ./automation/collect_windows_diagnostics.ps1 -AppExe "$env:APP_EXE"
+
       - name: Upload UI test artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -116,6 +122,7 @@ jobs:
           name: desktop-ui-test-artifacts
           path: |
             automation/pytest.log
+            automation/artifacts
             automation/screenshots
             automation/test-results
           if-no-files-found: warn

--- a/automation/collect_windows_diagnostics.ps1
+++ b/automation/collect_windows_diagnostics.ps1
@@ -1,0 +1,55 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppExe,
+    [int]$EventMinutes = 30,
+    [string]$OutputDir = "automation/artifacts"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $AppExe)) {
+    throw "APP_EXE does not exist: $AppExe"
+}
+
+$resolvedAppExe = (Resolve-Path -LiteralPath $AppExe).Path
+$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$sessionDir = Join-Path $OutputDir "diag_$timestamp"
+New-Item -ItemType Directory -Path $sessionDir -Force | Out-Null
+
+$envInfo = Join-Path $sessionDir "env.txt"
+$eventInfo = Join-Path $sessionDir "eventlog.txt"
+$appRunInfo = Join-Path $sessionDir "app_run.txt"
+
+"APP_EXE=$resolvedAppExe" | Out-File -FilePath $envInfo -Encoding utf8
+"Python: $(Get-Command python | Select-Object -ExpandProperty Source)" | Out-File -FilePath $envInfo -Append -Encoding utf8
+"PowerShell: $($PSVersionTable.PSVersion)" | Out-File -FilePath $envInfo -Append -Encoding utf8
+"Windows: $([System.Environment]::OSVersion.VersionString)" | Out-File -FilePath $envInfo -Append -Encoding utf8
+
+"=== App launch (no --e2e) ===" | Out-File -FilePath $appRunInfo -Encoding utf8
+$proc = Start-Process -FilePath $resolvedAppExe -PassThru
+Start-Sleep -Seconds 5
+if (-not $proc.HasExited) {
+    Stop-Process -Id $proc.Id -Force
+    "Exit: forced termination after 5s (no --e2e)" | Out-File -FilePath $appRunInfo -Append -Encoding utf8
+} else {
+    "Exit code (no --e2e): $($proc.ExitCode)" | Out-File -FilePath $appRunInfo -Append -Encoding utf8
+}
+
+"=== App launch (--e2e) ===" | Out-File -FilePath $appRunInfo -Append -Encoding utf8
+$procE2e = Start-Process -FilePath $resolvedAppExe -ArgumentList "--e2e" -PassThru
+Start-Sleep -Seconds 5
+if (-not $procE2e.HasExited) {
+    Stop-Process -Id $procE2e.Id -Force
+    "Exit: forced termination after 5s (--e2e)" | Out-File -FilePath $appRunInfo -Append -Encoding utf8
+} else {
+    "Exit code (--e2e): $($procE2e.ExitCode)" | Out-File -FilePath $appRunInfo -Append -Encoding utf8
+}
+
+$startTime = (Get-Date).AddMinutes(-1 * $EventMinutes)
+"=== Application error events (last $EventMinutes minutes) ===" | Out-File -FilePath $eventInfo -Encoding utf8
+Get-WinEvent -FilterHashtable @{ LogName = "Application"; StartTime = $startTime } |
+    Where-Object { $_.Id -in 1000, 1001 } |
+    Select-Object TimeCreated, Id, LevelDisplayName, ProviderName, Message |
+    Format-List | Out-File -FilePath $eventInfo -Append -Encoding utf8
+
+"Output directory: $sessionDir" | Write-Output


### PR DESCRIPTION
### Motivation
- Capture runtime information and Windows diagnostics when `APP_EXE` fails during UI tests to speed root-cause analysis.  
- Make the diagnostics runnable on the Windows self-hosted runner and produce files that can be retrieved from CI.  
- Ensure diagnostic outputs are uploaded alongside existing UI test artifacts so they are available after CI runs.

### Description
- Add `automation/collect_windows_diagnostics.ps1` which accepts `-AppExe`, `-EventMinutes`, and `-OutputDir`, resolves the executable, and writes results to `automation/artifacts/diag_YYYYMMDD_HHMMSS` including `env.txt`, `app_run.txt`, and `eventlog.txt`.
- The script launches the app with and without `--e2e`, waits 5 seconds to record exit codes or force-terminates, and collects Application event log entries (IDs `1000`/`1001`) from the last `EventMinutes`.
- Update `.github/workflows/desktop-build.yml` to add a `Collect diagnostics on failure` step using `if: failure()` that runs `./automation/collect_windows_diagnostics.ps1 -AppExe "$env:APP_EXE"`.
- Include `automation/artifacts` in the `desktop-ui-test-artifacts` upload so diagnostics are retained by the workflow.

### Testing
- No automated unit or integration tests were executed for the diagnostic helper script.  
- Workflow changes were applied and committed successfully, and the new workflow step is present in `.github/workflows/desktop-build.yml`.  
- End-to-end verification was not performed in CI as this change only adds a failure-triggered diagnostics collection step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0d3d1d64833392d6efb3e5a49af7)