### PR TITLE
Add OGS (Obligation Gate System) training course pages and landing card

### DIFF
--- a/index.html
+++ b/index.html
@@ -982,6 +982,7 @@
                 <span class="pill"><span class="spark" aria-hidden="true"></span>RIGEL: <b>1日1時間 / 10日</b></span>
                 <span class="pill"><span class="spark" aria-hidden="true"></span>SPICA: <b>1日1時間 / 14日</b></span>
                 <span class="pill"><span class="spark" aria-hidden="true"></span>SIRIUS: <b>1日1時間 / 14日</b></span>
+                <span class="pill"><span class="spark" aria-hidden="true"></span>OGS: <b>1日1時間 / 10日</b></span>
               </div>
             </div>
           </div>
@@ -1004,6 +1005,7 @@
                 <li><a href="ec/index.html"><span class="kbd">RIGEL</span>：Eカード（カイジ）で観点束Sとobligation A(S)を定義し、DTD（集合被覆）テスト生成まで動かす</a></li>
                 <li><a href="btd/overview.html"><span class="kbd">SPICA</span>：Beat Diffusionで“条件付き生成”をつくる（仕様→動くイメージ→設計→実装）</a></li>
                 <li><a href="rl/index.html"><span class="kbd">SIRIUS</span>：Bandit→MDP→Q-learning をGitHub運用で攻略するRLコース</a></li>
+                <li><a href="ogs/index.html"><span class="kbd">OGS</span>：PULL運用とobligationゲートで品質合格を設計するコース</a></li>
                 <li><span class="kbd">DENEB</span>：QR→CSVを型ファーストで作る（1週間）</li>
                 <li><a href="qr/samples.html"><span class="kbd">DENEB Samples</span>：テスト用サンプルQR（フォーマット別）</a></li>
                 <li>各コースは <span class="kbd">scope / index / overview / spec</span> へ（DENEBは <span class="kbd">index / overview / spec / samples</span>、SPICAは <span class="kbd">overview / spec / design / implement</span>、RIGELは <span class="kbd">scope / index / ecard_spec / spec</span>）</li>
@@ -1367,6 +1369,86 @@
               <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>提出フローを見る</a>
               <a class="btn" href="rl/spec.html"><span class="dot" aria-hidden="true"></span>動く仕様書を開く</a>
               <a class="btn primary" href="rl/index.html"><span class="dot" aria-hidden="true"></span>SIRIUSを開始</a>
+            </div>
+          </article>
+
+          <!-- OGS -->
+          <article class="course" id="ogs" aria-label="コース OGS（Obligation Gate System）">
+            <div class="courseHead">
+              <div class="courseName">
+                <span class="tag hot"><span class="chip" aria-hidden="true"></span>NEW コース OGS</span>
+                <h4>OGS</h4>
+                <p>
+                  PULL型のQueue運用とobligation（a1〜a12）を軸に、品質合格を再現可能にする運用設計コース。
+                  Evidenceと監査ログを最終判断に結びつけ、GateBoardで進捗と合格可否を可視化します。
+                </p>
+              </div>
+
+              <div class="courseMeta">
+                <div><b>学習目安</b></div>
+                <div>1日1時間 / 10日</div>
+              </div>
+            </div>
+
+            <div class="links" role="list">
+              <a class="linkCard" role="listitem" href="ogs/scope.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M12 6v12M6 12h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M4 8c3-4 13-4 16 0M4 16c3 4 13 4 16 0" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>Scope / 到達イメージ</b>
+                  <small>ogs/scope.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="ogs/index.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M7 7h10M7 12h10M7 17h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M4 6a2 2 0 0 1 2-2h12v16a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6Z" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>Index / 進め方</b>
+                  <small>ogs/index.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="ogs/overview.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M4 6h16M4 12h16M4 18h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M7 6v12M17 6v12" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity=".65"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>Overview / マニュアル</b>
+                  <small>ogs/overview.html</small>
+                </div>
+              </a>
+
+              <a class="linkCard" role="listitem" href="ogs/spec.html">
+                <div class="ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M8 12h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M12 8v8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                </div>
+                <div class="t">
+                  <b>Spec / 技術スタック</b>
+                  <small>ogs/spec.html</small>
+                </div>
+              </a>
+            </div>
+
+            <div class="courseFoot">
+              <a class="btn" href="#flow"><span class="dot" aria-hidden="true"></span>提出フローを見る</a>
+              <a class="btn" href="ogs/overview.html"><span class="dot" aria-hidden="true"></span>マニュアルを読む</a>
+              <a class="btn primary" href="ogs/index.html"><span class="dot" aria-hidden="true"></span>OGSを開始</a>
             </div>
           </article>
 

--- a/ogs/index.html
+++ b/ogs/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>OGS | Index</title>
+  <link rel="stylesheet" href="ogs-theme.css" />
+</head>
+<body class="ogs-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>OGS Course | Obligation Gate System</p>
+        </div>
+      </div>
+
+      <nav aria-label="OGSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a href="scope.html">Scope</a>
+          <a class="active" href="index.html">Index</a>
+          <a href="overview.html">Overview</a>
+          <a href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>技術仕様へ</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a href="scope.html">Scope</a>
+        <a class="active" href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>技術仕様へ</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap ogs-content">
+    <section class="ogs-card ogs-hero">
+      <p class="eyebrow">OGS (Obligation Gate System)</p>
+      <h1>Index / 進め方</h1>
+      <p class="lede">
+        PULL型運用とobligation運用を10日で一気に把握するためのガイド。
+        1日のアウトプットは「GateBoardに映る状態」と「Evidenceが残る状態」です。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="overview.html"><span class="dot" aria-hidden="true"></span>全体像を読む</a>
+        <a class="btn" href="scope.html"><span class="dot" aria-hidden="true"></span>Scopeへ戻る</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="OGS内部ナビゲーション">
+        <a href="scope.html">Scope</a>
+        <a class="active" href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">標準フロー（学習の順番）</div>
+      <ol>
+        <li><b>キャンペーン作成</b>：目的と期間、対象ロールを決める。</li>
+        <li><b>Obligationカタログ確認</b>：a1〜a12のDoD・証跡要件を読み解く。</li>
+        <li><b>obligation初期化</b>：キャンペーンごとにObligationItemを生成しQueueへ。</li>
+        <li><b>claim → 実行</b>：memberがPULLでclaimし、WIP制限を守って実行する。</li>
+        <li><b>結果提出 + Evidence</b>：PASS/FAIL/Blockedと証跡を同時に残す。</li>
+        <li><b>レビュー承認</b>：必要に応じてreviewer/adminが承認する。</li>
+        <li><b>GateBoard確認</b>：a1〜a12の達成状況を可視化して確認。</li>
+        <li><b>Judge OK</b>：leader/adminが最終判断を監査ログに記録。</li>
+      </ol>
+      <div class="callout">各ステップは「実施した証跡が残ること」を合否判断の中心に置きます。</div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">10日プラン例</div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Day</th><th>テーマ</th><th>アウトプット</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>OGS全体像</td><td>W/E/S*/A(S*)を自分の言葉で説明</td></tr>
+            <tr><td>2</td><td>Obligation Catalog</td><td>a1〜a12のDoDと証跡要件を整理</td></tr>
+            <tr><td>3</td><td>Queue / Claim</td><td>WIP制限・二重claim防止のルール設計</td></tr>
+            <tr><td>4</td><td>Evidence & Audit</td><td>監査ログの粒度と保存方針をまとめる</td></tr>
+            <tr><td>5</td><td>ExceptionApproved</td><td>例外承認フローと記録項目を整備</td></tr>
+            <tr><td>6</td><td>GateBoard</td><td>可視化に必要な状態データを設計</td></tr>
+            <tr><td>7</td><td>Evaluation</td><td>Green/Yellow/Red判定条件を定義</td></tr>
+            <tr><td>8</td><td>Judge OK</td><td>最終判断の監査ログを設計</td></tr>
+            <tr><td>9</td><td>技術スタック</td><td>FastAPI/Redis/Celeryの役割を整理</td></tr>
+            <tr><td>10</td><td>総まとめ</td><td>GateBoardとAuditの整合性チェック</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">提出物の粒度</div>
+      <ul>
+        <li>必ず「どのobligation（a1〜a12）に影響したか」を明記する。</li>
+        <li>Evidenceの種類（ログ/CI/リンク/画像など）を列挙する。</li>
+        <li>Blockedの場合は理由と解決タスクをPULL化する。</li>
+      </ul>
+      <div class="callout warn">Doneの曖昧さを排除するため、Evidenceの欠落は合格扱いにしません。</div>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+</body>
+</html>

--- a/ogs/ogs-theme.css
+++ b/ogs/ogs-theme.css
@@ -1,0 +1,143 @@
+@import url("../bt30/altair-theme.css");
+
+body.ogs-page {
+  margin: 0;
+}
+
+.ogs-content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 16px auto 32px;
+}
+
+.ogs-hero {
+  display: grid;
+  gap: 14px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.lede {
+  margin: 10px 0 0;
+  color: var(--muted);
+  line-height: 1.8;
+  max-width: 80ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.subnav {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.subnav a {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.subnav a.active {
+  color: var(--text);
+  border-color: rgba(124, 247, 255, 0.32);
+  box-shadow: 0 0 0 3px rgba(124, 247, 255, 0.16) inset;
+}
+
+.ogs-card {
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.ogs-card::before {
+  content: "";
+  position: absolute;
+  inset: -80px;
+  background:
+    radial-gradient(420px 180px at 20% 20%, rgba(124, 247, 255, 0.1), transparent 60%),
+    radial-gradient(420px 160px at 80% 70%, rgba(167, 139, 250, 0.09), transparent 62%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.ogs-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.ogs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 14px;
+}
+
+.stat-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.stat {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.24);
+  border-radius: 14px;
+  padding: 12px;
+}
+
+.stat strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--text);
+}
+
+.stat span {
+  color: var(--muted);
+}
+
+.callout {
+  border-left: 4px solid var(--accent);
+  padding: 12px 14px;
+  background: rgba(124, 247, 255, 0.08);
+  border-radius: 12px;
+  color: var(--muted);
+}
+
+.callout.warn {
+  border-left-color: var(--gold);
+  background: rgba(255, 211, 110, 0.1);
+}
+
+.callout.good {
+  border-left-color: #63f2a1;
+  background: rgba(99, 242, 161, 0.12);
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+@media (max-width: 960px) {
+  .nav {
+    justify-content: flex-start;
+  }
+}

--- a/ogs/overview.html
+++ b/ogs/overview.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>OGS | Overview</title>
+  <link rel="stylesheet" href="ogs-theme.css" />
+</head>
+<body class="ogs-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>OGS Course | Obligation Gate System</p>
+        </div>
+      </div>
+
+      <nav aria-label="OGSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a href="scope.html">Scope</a>
+          <a href="index.html">Index</a>
+          <a class="active" href="overview.html">Overview</a>
+          <a href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>技術仕様へ</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a class="active" href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>技術仕様へ</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap ogs-content">
+    <section class="ogs-card ogs-hero">
+      <p class="eyebrow">OGS (Obligation Gate System)</p>
+      <h1>Overview / 学習&応用マニュアル</h1>
+      <p class="lede">
+        PULL型運用とobligation中心の品質合格モデルを、初心者エンジニアが理解・応用できるように整理した学習用マニュアル。
+        Doneの曖昧さを排除し、Evidenceと監査ログで判断できる運用を作ります。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="spec.html"><span class="dot" aria-hidden="true"></span>技術仕様へ</a>
+        <a class="btn" href="index.html"><span class="dot" aria-hidden="true"></span>学習手順へ</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="OGS内部ナビゲーション">
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a class="active" href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">システムの特徴（要約）</div>
+      <ul>
+        <li><b>PULL型運用</b>：仕事は「割当」ではなく「引く」。WIP制限と二重claim防止を設計。</li>
+        <li><b>obligation中心</b>：テスト技法ではなくa1〜a12の合格義務で品質を収束。</li>
+        <li><b>Evidence / 監査ログ</b>：実施した証跡がJudge OKを支える。</li>
+        <li><b>例外承認フロー</b>：ExceptionApprovedも監査可能な状態で記録。</li>
+        <li><b>GateBoard可視化</b>：a1〜a12の進捗と品質合格を即座に把握。</li>
+      </ul>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">主要コンセプト（W / E / S* / A(S*)）</div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>記号</th><th>意味</th><th>OGSでの扱い</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>W</td><td>連続的な可能性空間</td><td>キャンペーンごとにWorldSnapshotを持つ</td></tr>
+            <tr><td>E</td><td>制約／評価情報</td><td>E_quality（Exit Criteria）とE_pull（PULL制約）</td></tr>
+            <tr><td>S*</td><td>ゲートobligation観点</td><td>テスト技法ではなくobligation視点で整理</td></tr>
+            <tr><td>A(S*)</td><td>キューに積める離散単位</td><td>ObligationItemとしてa1〜a12を生成</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout">観点を「技法」ではなく「合格義務」に置き換えることで、運用と判断が明確になります。</div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">役割と責務</div>
+      <div class="ogs-grid">
+        <div>
+          <h3>member</h3>
+          <p>Queueからclaimし、実行結果とEvidenceを提出する。</p>
+        </div>
+        <div>
+          <h3>leader</h3>
+          <p>キャンペーン作成・obligation初期化・Judge OKを担う。</p>
+        </div>
+        <div>
+          <h3>admin</h3>
+          <p>システム全体の管理権限。例外承認の最終責任者。</p>
+        </div>
+        <div>
+          <h3>reviewer</h3>
+          <p>Evidenceのレビュー承認を担当（任意）。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">典型フロー（初心者の道順）</div>
+      <ol>
+        <li>キャンペーン作成（leader/admin）</li>
+        <li>Obligationカタログ確認（全ロール）</li>
+        <li>obligation初期化（leader/admin）</li>
+        <li>キュー確認 & claim（member/leader/admin）</li>
+        <li>結果提出（PASS/FAIL/Blocked）</li>
+        <li>Evidence追加</li>
+        <li>レビュー承認（任意）</li>
+        <li>GateBoard / Evaluation確認</li>
+        <li>Judge OK確定</li>
+      </ol>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">機能別の学習ポイント</div>
+      <div class="ogs-grid">
+        <div>
+          <h3>Obligation Catalog</h3>
+          <p>DoD・証跡・依存関係をデータとして定義し、運用と実装を分離する。</p>
+        </div>
+        <div>
+          <h3>Queue / Claim</h3>
+          <p>READYな項目のみを表示し、WIP制限と二重claim防止を仕組みにする。</p>
+        </div>
+        <div>
+          <h3>結果提出 & Blocked</h3>
+          <p>DoDを満たした後にPASS/FAILを確定し、Blockedは理由と解決タスクを残す。</p>
+        </div>
+        <div>
+          <h3>Evidence</h3>
+          <p>監査に耐える証跡構造を用意し、評価判断の裏付けに使う。</p>
+        </div>
+        <div>
+          <h3>ExceptionApproved</h3>
+          <p>例外でも必ず理由・承認者・時刻を記録し、GateBoardで注記付きでPass扱い。</p>
+        </div>
+        <div>
+          <h3>GateBoard / Evaluation</h3>
+          <p>a1〜a12の進捗と品質合格可否をリアルタイムに可視化する。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">監査イベント（Audit Events）</div>
+      <p>主要操作はAudit Eventsとして記録し、トラブルシュートと監査対応に備える。</p>
+      <ul>
+        <li>claim / submit / evidence / exception / judge を必須イベントとして残す。</li>
+        <li>イベントと状態更新の順序（イベント先行 or 状態先行）を明示。</li>
+        <li>GateBoardは状態データ、監査はイベントデータを参照。</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+</body>
+</html>

--- a/ogs/scope.html
+++ b/ogs/scope.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>OGS | Scope</title>
+  <link rel="stylesheet" href="ogs-theme.css" />
+</head>
+<body class="ogs-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>OGS Course | Obligation Gate System</p>
+        </div>
+      </div>
+
+      <nav aria-label="OGSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a class="active" href="scope.html">Scope</a>
+          <a href="index.html">Index</a>
+          <a href="overview.html">Overview</a>
+          <a href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="index.html"><span class="dot" aria-hidden="true"></span>Indexへ進む</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a class="active" href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="index.html"><span class="dot" aria-hidden="true"></span>Indexへ進む</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap ogs-content">
+    <section class="ogs-card ogs-hero">
+      <p class="eyebrow">OGS (Obligation Gate System)</p>
+      <h1>Scope / 到達イメージ</h1>
+      <p class="lede">
+        PULL型の運用とオブリゲーション（a1〜a12）を軸に、品質合格を再現可能にするトレーニングコース。
+        運用設計・監査性・品質判断の分離を学び、GateBoardとJudge OKまで一連の流れを理解します。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="index.html"><span class="dot" aria-hidden="true"></span>Indexを開く</a>
+        <a class="btn" href="overview.html"><span class="dot" aria-hidden="true"></span>全体像を読む</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="OGS内部ナビゲーション">
+        <a class="active" href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">学習のゴール</div>
+      <div class="stat-list">
+        <div class="stat"><strong>期間の目安</strong><span>1日1時間 × 10日</span></div>
+        <div class="stat"><strong>対象ロール</strong><span>member / leader / admin / reviewer</span></div>
+        <div class="stat"><strong>主なテーマ</strong><span>PULL運用・obligation設計・監査性</span></div>
+        <div class="stat"><strong>アウトプット</strong><span>GateBoardとJudge OKの運用像</span></div>
+      </div>
+      <div class="callout">実装ではなく「運用設計」と「品質合格の可視化」にフォーカスしたコースです。</div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">成果物イメージ</div>
+      <ul>
+        <li>Obligation Catalog（a1〜a12）とDoD・証跡要件の整理。</li>
+        <li>キャンペーン単位のObligationItem生成とQueue運用フロー。</li>
+        <li>EvidenceとAudit Eventsを用いた監査可能なログ構造。</li>
+        <li>GateBoard / Evaluation / Judge OKの可視化と最終判断の記録。</li>
+      </ul>
+      <div class="callout good">最終的に「誰が・いつ・何を・どの義務で合格させたか」を説明できる状態が到達点です。</div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">ロール分離の学び</div>
+      <div class="ogs-grid">
+        <div>
+          <h3>member</h3>
+          <p>キューからObligationItemをclaimし、実行結果とEvidenceを提出する。</p>
+        </div>
+        <div>
+          <h3>leader / admin</h3>
+          <p>キャンペーン作成・obligation初期化・Judge OKの確定を担う。</p>
+        </div>
+        <div>
+          <h3>reviewer（任意）</h3>
+          <p>Evidenceと結果のレビュー承認で品質判断を補強する。</p>
+        </div>
+      </div>
+      <div class="callout warn">実行者と判断者を分離することで、PULL実行と品質判断が混ざらない状態を作ります。</div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">対象外 / 非ゴール</div>
+      <ul>
+        <li>実装言語の詳細チューニング（API実装の最適化など）。</li>
+        <li>確率的に揺れるテストや、運に依存した合格判定。</li>
+        <li>テスト技法の網羅よりも、obligationベースの合格義務を優先。</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+</body>
+</html>

--- a/ogs/spec.html
+++ b/ogs/spec.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>OGS | Spec</title>
+  <link rel="stylesheet" href="ogs-theme.css" />
+</head>
+<body class="ogs-page">
+  <a class="skip" href="#main">本文へスキップ</a>
+  <canvas id="starfield" aria-hidden="true"></canvas>
+
+  <header class="course-header">
+    <div class="wrap nav">
+      <div class="brand">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Python Training</h1>
+          <p>OGS Course | Obligation Gate System</p>
+        </div>
+      </div>
+
+      <nav aria-label="OGSナビゲーション">
+        <div class="navlinks">
+          <a href="../index.html">Homeへ戻る</a>
+          <a href="scope.html">Scope</a>
+          <a href="index.html">Index</a>
+          <a href="overview.html">Overview</a>
+          <a class="active" href="spec.html">Spec</a>
+        </div>
+        <div class="cta">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="overview.html"><span class="dot" aria-hidden="true"></span>概要へ戻る</a>
+        </div>
+        <button class="hamburger" id="hamburger" aria-expanded="false" aria-label="メニューを開く">
+          <span aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+
+    <div class="mobile" id="mobile">
+      <div class="mobilePanel" role="dialog" aria-label="モバイルメニュー">
+        <a href="../index.html">Homeへ戻る</a>
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a class="active" href="spec.html">Spec</a>
+        <div class="row">
+          <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>コース一覧</a>
+          <a class="btn primary" href="overview.html"><span class="dot" aria-hidden="true"></span>概要へ戻る</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrap ogs-content">
+    <section class="ogs-card ogs-hero">
+      <p class="eyebrow">OGS (Obligation Gate System)</p>
+      <h1>Spec / 技術スタックと設計指針</h1>
+      <p class="lede">
+        FastAPI・Redis・Celeryを組み合わせて、PULL運用と監査ログを両立させる実装設計。
+        「状態」と「監査」を分離し、GateBoardとEvaluationが正確に収束することを優先します。
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="overview.html"><span class="dot" aria-hidden="true"></span>概要へ戻る</a>
+        <a class="btn" href="index.html"><span class="dot" aria-hidden="true"></span>Indexを見る</a>
+        <a class="btn" href="../index.html#courses"><span class="dot" aria-hidden="true"></span>Homeへ戻る</a>
+      </div>
+      <div class="subnav" aria-label="OGS内部ナビゲーション">
+        <a href="scope.html">Scope</a>
+        <a href="index.html">Index</a>
+        <a href="overview.html">Overview</a>
+        <a class="active" href="spec.html">Spec</a>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">技術スタックの役割</div>
+      <div class="ogs-grid">
+        <div>
+          <h3>FastAPI</h3>
+          <p>キャンペーン作成、queue一覧、claim、結果提出、evaluationなどの主要APIを提供。</p>
+        </div>
+        <div>
+          <h3>Redis</h3>
+          <p>状態管理・インデックス・監査イベント（Streams）を保持し、読み取り用途と監査用途を分離。</p>
+        </div>
+        <div>
+          <h3>Celery</h3>
+          <p>Ready再計算、放置claim回収、滞留検知などの非同期処理を担当。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">主要データモデル</div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>データ</th><th>役割</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Campaign</td><td>WorldSnapshotと対象obligationを束ねる単位。</td></tr>
+            <tr><td>ObligationCatalog</td><td>a1〜a12のDoD・証跡・依存関係を定義。</td></tr>
+            <tr><td>ObligationItem</td><td>キャンペーンごとの実行単位。Queueに積まれる。</td></tr>
+            <tr><td>Evidence</td><td>実施した証跡（ログ/CI/リンクなど）。</td></tr>
+            <tr><td>AuditEvent</td><td>claim/submit/evidence/exception/judgeを記録。</td></tr>
+            <tr><td>ExceptionApproved</td><td>例外承認の理由・承認者・時刻を保持。</td></tr>
+            <tr><td>GateBoard</td><td>a1〜a12の進捗と合格可否を集計表示。</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">主要APIの整理</div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>API</th><th>目的</th><th>備考</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>POST /campaigns</td><td>キャンペーン作成</td><td>WorldSnapshotと期間を登録</td></tr>
+            <tr><td>POST /campaigns/{id}/init</td><td>obligation初期化</td><td>ObligationItem生成とQueue投入</td></tr>
+            <tr><td>GET /queue</td><td>READY一覧</td><td>WIP制限を反映</td></tr>
+            <tr><td>POST /queue/{item}/claim</td><td>claim</td><td>二重claim防止・冪等性</td></tr>
+            <tr><td>POST /items/{id}/submit</td><td>結果提出</td><td>PASS/FAIL/Blocked</td></tr>
+            <tr><td>POST /items/{id}/evidence</td><td>Evidence追加</td><td>監査イベント同時記録</td></tr>
+            <tr><td>POST /items/{id}/exception</td><td>例外承認</td><td>理由・承認者・時刻</td></tr>
+            <tr><td>GET /gateboard</td><td>GateBoard</td><td>Exit Criteriaに基づく集計</td></tr>
+            <tr><td>POST /judge-ok</td><td>Judge OK</td><td>最終判断を監査ログへ</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">Celeryタスク（非同期処理）</div>
+      <ul>
+        <li>Ready再計算：DoD達成度と依存関係をもとにQueueを更新。</li>
+        <li>放置claim回収：期限超過のclaimを解放し再投入。</li>
+        <li>滞留検知：Blockedや長期停滞を検出して通知。</li>
+      </ul>
+      <div class="callout">タスクは冪等性を前提にし、再実行に耐える設計とする。</div>
+    </section>
+
+    <section class="ogs-card">
+      <div class="badge">技術スタッフ向けチェックリスト</div>
+      <ol>
+        <li>API操作が監査イベントとして必ず記録されるか。</li>
+        <li>claim/submit/evidenceの状態遷移が矛盾しないか。</li>
+        <li>GateBoard/Evaluationが最新状態を反映できるか。</li>
+        <li>Celeryタスクが冪等で再実行可能か。</li>
+        <li>例外承認（ExceptionApproved）が監査可能か。</li>
+      </ol>
+    </section>
+  </main>
+
+  <script src="../bt30/altair_shared.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Introduce a new training course “OGS (Obligation Gate System)” to teach PULL-based Queue/Worker operation and obligation-driven quality gates (a1–a12). 
- Provide a small, self-contained set of static pages (Scope / Index / Overview / Spec) so the course appears in the site navigation and can be reviewed in-place. 
- Keep changes minimal and consistent with the existing site layout and theme patterns used by other courses. 

### Description
- Updated `index.html` to add an OGS shortcut in the Quick Start list and a new OGS course card in the `#courses` grid. 
- Added `ogs/` directory with `index.html`, `scope.html`, `overview.html`, and `spec.html` implementing the course content and navigation. 
- Added course-specific stylesheet `ogs/ogs-theme.css` that imports existing `bt30/altair-theme.css` to reuse shared styling and maintain consistent visuals. 
- Minor runtime aid: course pages reference the existing `bt30/altair_shared.js` starfield script to match other course pages and visual previews. 

### Testing
- Automated tests: none run because this is a content-only static-site addition and no code or unit tests were modified. 
- Local preview: served site with `python -m http.server` and captured a headless screenshot via Playwright to verify the landing page and new course card rendered (succeeded). 
- Seed / Algorithm / Steps: `N/A`. 
- Time Spent(min) / Trials / Outcome / Notes: `45 / 1 / Pass / Visual check only` ; `A_j (影響obligation): none`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ddd60f08833385e120f9020fbe37)